### PR TITLE
Integrate `ld+json` structured data for article and news-article

### DIFF
--- a/src/generate-common-seo.js
+++ b/src/generate-common-seo.js
@@ -30,12 +30,17 @@ export function generateStructuredData(config) {
   const themeConfig = config["theme-attributes"];
   const socialLinks = config["social-links"];
 
+  if(!themeConfig || !themeConfig.logo) {
+    return {};
+  }
+
   return {
     organization: {
       name: title,
       url: config["sketches-host"],
       logo: themeConfig ? themeConfig.logo : "https://quintype.com/logo.png",
       sameAs: socialLinks ? Object.values(socialLinks) : []
-    }
+    },
+    enableNewsArticle: themeConfig['news-article'] ? themeConfig['news-article'] : false
   }
 }

--- a/src/generate-common-seo.js
+++ b/src/generate-common-seo.js
@@ -38,9 +38,9 @@ export function generateStructuredData(config) {
     organization: {
       name: title,
       url: config["sketches-host"],
-      logo: themeConfig ? themeConfig.logo : "https://quintype.com/logo.png",
+      logo: themeConfig.logo,
       sameAs: socialLinks ? Object.values(socialLinks) : []
     },
-    enableNewsArticle: themeConfig['news-article'] ? themeConfig['news-article'] : false
+    enableNewsArticle: !!themeConfig['structured_data_news_article'],
   }
 }

--- a/src/structured-data-tags.js
+++ b/src/structured-data-tags.js
@@ -13,7 +13,7 @@ function ldJson(type, fields) {
 function generateArticleData (story = {}, publisherConfig = {}){
   const metaKeywords = story.seo && story.seo['meta-keywords'] || [];
   const { authors = [] } = story;
-  const {themeConfig = {}} = publisherConfig["theme-attributes"];
+  const {themeConfig = {}} = publisherConfig["theme-attributes"] || {};
 
   return {
     "author": authors.map(author => ({
@@ -22,14 +22,6 @@ function generateArticleData (story = {}, publisherConfig = {}){
       "name": author.name
     })),
     "keywords": metaKeywords,
-    "publisher": {
-      "@type": "Organization",
-      "name": publisherConfig['publisher-name'],
-      "logo": {
-        "@type": "ImageObject",
-        "url": themeConfig.logo ? themeConfig.logo : "https://quintype.com/logo.png",
-      }
-    },
     "url": `${publisherConfig['sketches-host']}/${story.slug}`,
     "dateCreated": new Date(story['created-at']),
     "dateModified": new Date(story['updated-at']),
@@ -49,7 +41,7 @@ function generateNewsArticleData (story = {}, publisherConfig = {}) {
 
 export function StructuredDataTags({structuredData = {}}, config, pageType, response = {}, {url}) {
   const tags = [];
-  const {story = {}} = response.data;
+  const {story = {}} = response.data || {};
   const {config: publisherConfig = {}} = response;
   const {articleType = ''} = publisherConfig['publisher-settings'] || {};
 
@@ -61,8 +53,13 @@ export function StructuredDataTags({structuredData = {}}, config, pageType, resp
     tags.push(ldJson("Organization", structuredData.organization));
   }
 
-  if(articleType === 'news-article') {
-    const newsArticleData = Object.assign({}, articleData, generateNewsArticleData(story, publisherConfig));
+  if(structuredData.organization && structuredData.enableNewsArticle) {
+    const publisherObject = {
+      "@type": "Organization",
+      "@context": "http://schema.org",
+      "publisher" : structuredData.organization
+    };
+    const newsArticleData = Object.assign({}, articleData, generateNewsArticleData(story, publisherConfig), publisherObject);
     tags.push(ldJson('NewsArticle', newsArticleData));
   }
 

--- a/src/structured-data-tags.js
+++ b/src/structured-data-tags.js
@@ -21,7 +21,6 @@ function generateArticleData (story = {}, publisherConfig = {}){
       "givenName": author.name,
       "name": author.name
     })),
-    "editor": story['owner-name'],
     "keywords": metaKeywords,
     "publisher": {
       "@type": "Organization",

--- a/src/structured-data-tags.js
+++ b/src/structured-data-tags.js
@@ -12,11 +12,16 @@ function ldJson(type, fields) {
 
 function generateArticleData (story = {}, publisherConfig = {}){
   const metaKeywords = story.seo && story.seo['meta-keywords'] || [];
+  const { authors = [] } = story;
   return {
-    "author": story['author-name'],
-    "editor": story['author-name'],
+    "author": authors.map(author => ({
+        "@type": "Person",
+        "givenName": author.name,
+        "name": author.name
+    })),
+    "editor": story['owner-name'],
     "keywords": metaKeywords,
-    "publisher": story['author-name'],
+    "publisher": publisherConfig['publisher-name'],
     "url": `${publisherConfig['sketches-host']}/${story.slug}`,
     "dateCreated": new Date(story['created-at']),
     "dateModified": new Date(story['updated-at']),

--- a/src/structured-data-tags.js
+++ b/src/structured-data-tags.js
@@ -13,15 +13,24 @@ function ldJson(type, fields) {
 function generateArticleData (story = {}, publisherConfig = {}){
   const metaKeywords = story.seo && story.seo['meta-keywords'] || [];
   const { authors = [] } = story;
+  const {themeConfig = {}} = publisherConfig["theme-attributes"];
+
   return {
     "author": authors.map(author => ({
-        "@type": "Person",
-        "givenName": author.name,
-        "name": author.name
+      "@type": "Person",
+      "givenName": author.name,
+      "name": author.name
     })),
     "editor": story['owner-name'],
     "keywords": metaKeywords,
-    "publisher": publisherConfig['publisher-name'],
+    "publisher": {
+      "@type": "Organization",
+      "name": publisherConfig['publisher-name'],
+      "logo": {
+        "@type": "ImageObject",
+        "url": themeConfig.logo ? themeConfig.logo : "https://quintype.com/logo.png",
+      }
+    },
     "url": `${publisherConfig['sketches-host']}/${story.slug}`,
     "dateCreated": new Date(story['created-at']),
     "dateModified": new Date(story['updated-at']),
@@ -29,19 +38,20 @@ function generateArticleData (story = {}, publisherConfig = {}){
 }
 
 function generateNewsArticleData (story = {}, publisherConfig = {}) {
+  const {alternative = {}} = story.alternative || {};
   return {
     'headline' : story.headline,
-    "alternativeHeadline": story.subheadline,
-    "image": [`${publisherConfig['cdn-image']}/${story['hero-image-s3-key']}`],
+    "alternativeHeadline": (alternative.home && alternative.home.default) ? alternative.home.default.headline : "",
+    "image": [`${publisherConfig['cdn-image']}/${story['hero-image-s3-key']}?w=480&auto=format%2Ccompress&fit=max`],
     "datePublished": new Date(story['published-at']),
     "description": story.summary,
   };
 }
 
-export function StructuredDataTags({structuredData = {}}, config, pageType, data = {}, {url}) {
+export function StructuredDataTags({structuredData = {}}, config, pageType, response = {}, {url}) {
   const tags = [];
-  const {story = {}} = data.data;
-  const {config: publisherConfig = {}} = data;
+  const {story = {}} = response.data;
+  const {config: publisherConfig = {}} = response;
   const {articleType = ''} = publisherConfig['publisher-settings'] || {};
 
   const articleData = generateArticleData(story, publisherConfig);

--- a/src/structured-data-tags.js
+++ b/src/structured-data-tags.js
@@ -10,11 +10,26 @@ function ldJson(type, fields) {
   };
 }
 
-export function StructuredDataTags({structuredData = {}}, config, pageType, data, {url}) {
+export function StructuredDataTags({structuredData = {}}, config, pageType, data = {}, {url}) {
   const tags = [];
+  const {story = {}, config: publisherConfig = {}} = data.data;
+  const {storyType = ''} = publisherConfig['publisher-settings'] || {};
+
+
+  const articleStructureData = {
+    'headline' : story.headline,
+    "alternativeHeadline": story.subheadline,
+    "image": [`${publisherConfig['cdn-image']}/${story['hero-image-s3-key']}`],
+    "datePublished": new Date(story['published-at']),
+    "description": story.summary,
+  };
 
   if(structuredData.organization) {
-    tags.push(ldJson("Organization", structuredData.organization))
+    tags.push(ldJson("Organization", structuredData.organization));
+  }
+
+  if(storyType === 'news-article') {
+    tags.push(ldJson('news-article', articleStructureData));
   }
 
   // All Pages have: Publisher, Site

--- a/src/structured-data-tags.js
+++ b/src/structured-data-tags.js
@@ -10,26 +10,46 @@ function ldJson(type, fields) {
   };
 }
 
-export function StructuredDataTags({structuredData = {}}, config, pageType, data = {}, {url}) {
-  const tags = [];
-  const {story = {}, config: publisherConfig = {}} = data.data;
-  const {storyType = ''} = publisherConfig['publisher-settings'] || {};
+function generateArticleData (story = {}, publisherConfig = {}){
+  const metaKeywords = story.seo && story.seo['meta-keywords'] || [];
+  return {
+    "author": story['author-name'],
+    "editor": story['author-name'],
+    "keywords": metaKeywords,
+    "publisher": story['author-name'],
+    "url": `${publisherConfig['sketches-host']}/${story.slug}`,
+    "dateCreated": new Date(story['created-at']),
+    "dateModified": new Date(story['updated-at']),
+  }
+}
 
-
-  const articleStructureData = {
+function generateNewsArticleData (story = {}, publisherConfig = {}) {
+  return {
     'headline' : story.headline,
     "alternativeHeadline": story.subheadline,
     "image": [`${publisherConfig['cdn-image']}/${story['hero-image-s3-key']}`],
     "datePublished": new Date(story['published-at']),
     "description": story.summary,
   };
+}
+
+export function StructuredDataTags({structuredData = {}}, config, pageType, data = {}, {url}) {
+  const tags = [];
+  const {story = {}} = data.data;
+  const {config: publisherConfig = {}} = data;
+  const {articleType = ''} = publisherConfig['publisher-settings'] || {};
+
+  const articleData = generateArticleData(story, publisherConfig);
+
+  tags.push(ldJson("Article", articleData));
 
   if(structuredData.organization) {
     tags.push(ldJson("Organization", structuredData.organization));
   }
 
-  if(storyType === 'news-article') {
-    tags.push(ldJson('news-article', articleStructureData));
+  if(articleType === 'news-article') {
+    const newsArticleData = Object.assign({}, articleData, generateNewsArticleData(story, publisherConfig));
+    tags.push(ldJson('NewsArticle', newsArticleData));
   }
 
   // All Pages have: Publisher, Site

--- a/test/generate_common_seo_test.js
+++ b/test/generate_common_seo_test.js
@@ -102,24 +102,18 @@ describe('Seo Helpers', function() {
           url: "abc.com",
           logo: "https://quintype.com/abc.png",
           sameAs: ["https://www.facebook.com/abc/", "", "https://www.instagram.com/abc", "https://twitter.com/abc"]
-        }
-      }
+        },
+        enableNewsArticle: false
+      };
       const actualStructuredData = generateStructuredData(config)
       assert.deepEqual(actualStructuredData, expectedStructuredData)
     })
   
     it('does not crash when the config is empty', function() {
-      const expectedStructuredData = {
-        organization: {
-          name: undefined,
-          url: undefined,
-          logo: "https://quintype.com/logo.png",
-          sameAs: []
-        }
-      }
-      const actualStructuredData = generateStructuredData({})
-      assert.deepEqual(actualStructuredData, expectedStructuredData)
-    })
+      const expectedStructuredData = {};
+      const actualStructuredData = generateStructuredData({});
+      assert.deepEqual(actualStructuredData, expectedStructuredData);
+    });
   
     it('does not crash when social links is null', function() {
       const config = {
@@ -132,7 +126,7 @@ describe('Seo Helpers', function() {
           "logo": "https://quintype.com/abc.png"
         },
         "social-links": null
-      }
+      };
   
       const expectedStructuredData = {
         organization: {
@@ -140,12 +134,13 @@ describe('Seo Helpers', function() {
           url: "abc.com",
           logo: "https://quintype.com/abc.png",
           sameAs: []
-        }
-      }
+        },
+        enableNewsArticle: false
+      };
   
-      const actualStructuredData = generateStructuredData(config)
+      const actualStructuredData = generateStructuredData(config);
       assert.deepEqual(actualStructuredData, expectedStructuredData)
-    })
+    });
   
     it('does not crash when theme attributes is null', function() {
       const config = {
@@ -161,19 +156,9 @@ describe('Seo Helpers', function() {
           "instagram-url": "https://www.instagram.com/abc",
           "twitter-url": "https://twitter.com/abc"
         }
-      }
-  
-      const expectedStructuredData = {
-        organization: {
-          name: "abc",
-          url: "abc.com",
-          logo: "https://quintype.com/logo.png",
-          sameAs: ["https://www.facebook.com/abc/", "", "https://www.instagram.com/abc", "https://twitter.com/abc"]
-        }
-      }
-  
-      const actualStructuredData = generateStructuredData(config)
-      assert.deepEqual(actualStructuredData, expectedStructuredData)
+      };
+      const actualStructuredData = generateStructuredData(config);
+      assert.deepEqual(actualStructuredData, {});
     })
   })
-})
+});

--- a/test/structured_data_tags_test.js
+++ b/test/structured_data_tags_test.js
@@ -16,10 +16,259 @@ describe('StructuredDataTags', function() {
             logo: "https://quintype.com/logo.png",
             sameAs: ["https://www.facebook.com/quintype","https://twitter.com/quintype_inc","https://plus.google.com/+quintype","https://www.youtube.com/user/Quintype"]
           }
-        }
-      }
-      const string = getSeoMetadata(seoConfig, {}, 'home-page', {}, {url: url.parse("/")})
+        },
+        "enableNewsArticle": false
+      };
+      const string = getSeoMetadata(seoConfig, {}, 'home-page', {}, {url: url.parse("/")});
       assertContains('<script type="application/ld+json">{"@type":"Organization","@context":"http://schema.org","name":"Quintype","url":"http://www.quintype.com/","logo":"https://quintype.com/logo.png","sameAs":["https://www.facebook.com/quintype","https://twitter.com/quintype_inc","https://plus.google.com/+quintype","https://www.youtube.com/user/Quintype"]}</script>', string);
-    }  );
+    });
+  });
+});
+
+
+describe('StructuredDataTags with news article data ', function() {
+  describe('On all pages', function() {
+    it("puts the news article along with article tag when news-article is truthy in theme-attributes config", function() {
+      const seoConfig = {
+        generators: [StructuredDataTags],
+        structuredData: {
+          organization: {
+            name: "Quintype",
+            url: "http://www.quintype.com/",
+            logo: "https://quintype.com/logo.png",
+            sameAs: ["https://www.facebook.com/quintype","https://twitter.com/quintype_inc","https://plus.google.com/+quintype","https://www.youtube.com/user/Quintype"]
+          },
+          enableNewsArticle: true
+        }
+      };
+
+      const data = {
+        data : {
+          story: {
+            "seo": {
+              "meta-description": "",
+              "meta-title": " Why publishers need to use personalised content",
+              "meta-keywords": [],
+              "meta-google-news-standout": false,
+              "claim-reviews": {
+                "story": null
+              }
+            },
+            "author-name": "Greeshma",
+            "tags": [],
+            "headline": "Personalise or perish - Why publishers need to use personalised content",
+            "slug": "politics/2018/02/28/personalise-or-perish---why-publishers-need-to-use-personalised-content",
+            "last-published-at": 1524204205102,
+            "alternative": {
+              "home": {
+                "default": {
+                  "headline": "Personalise or perish"
+                }
+              }
+            },
+            "content-created-at": 1519814417485,
+            "owner-name": "Greeshma",
+            "hero-image-metadata": {
+              "width": 1920,
+              "height": 1280,
+              "mime-type": "image/jpeg",
+              "focus-point": [
+                931,
+                901
+              ]
+            },
+            "published-at": 1524204205102,
+            "summary": "Personalised content marketing is the slayer weapon in this war for attention and engagement.",
+            "hero-image-s3-key": "quintype-demo/2018-03/a27aafbf-8a27-4f42-b78f-769eb04655d6/efa66751-e534-4a18-8ebe-e02189c356d9.jpg",
+            "cards": [],
+            "content-updated-at": 1524204468980,
+            "first-published-at": 1519816264773,
+            "created-at": 1524204200588,
+            "updated-at": 1524204200588,
+            "authors": [
+              {
+                "id": 482995,
+                "name": "Greeshma",
+                "slug": "greeshma",
+                "avatar-url": "https://images.assettype.com/quintype-demo/2018-03/9a16b150-6281-45e6-bdb9-6eb1146e1a54/50b1da06-b478-4bc8-8067-fada337c55d0.jpeg",
+                "avatar-s3-key": "quintype-demo/2018-03/9a16b150-6281-45e6-bdb9-6eb1146e1a54/50b1da06-b478-4bc8-8067-fada337c55d0.jpeg",
+                "twitter-handle": null,
+                "bio": null
+              }
+            ],
+            "metadata": {
+              "card-share": {
+                "shareable": true
+              }
+            },
+            "publish-at": null,
+          },
+        },
+        config: {
+          "cdn-image": "images.assettype.com",
+          "sketches-host": "https://madrid.quintype.io",
+          "publisher-name": "quintype-demo",
+          "publisher-settings": {
+            "title": "Quintype Demo",
+            "copyright": "© quintype-demo 2018"
+          },
+          "social-links": {
+            "facebook-url": "https://www.facebook.com/quintypeinc",
+            "twitter-url": "https://twitter.com/quintype_inc"
+          },
+          "publisher-theme": {
+            "monogram": "",
+            "logo": "",
+            "primary_color": "#000",
+            "secondary_color": "",
+            "header_text_color": "",
+            "header_background_color": "",
+            "footer_text_color": "",
+            "footer_background_color": "",
+            "dfp_network_id": "60988533"
+          },
+          "theme-attributes": {
+            "monogram": "",
+            "logo": "",
+            "primary_color": "#000",
+            "secondary_color": "",
+            "header_text_color": "",
+            "header_background_color": "",
+            "footer_text_color": "",
+            "footer_background_color": "",
+            "dfp_network_id": "60988533",
+            "news-article": true
+          }
+        }
+      };
+
+      const string = getSeoMetadata(seoConfig, {}, 'home-page', data, {url: url.parse("/")});
+
+      assertContains('<script type="application/ld+json">{"@type":"Article","@context":"http://schema.org","author":[{"@type":"Person","givenName":"Greeshma","name":"Greeshma"}],"keywords":[],"url":"https://madrid.quintype.io/politics/2018/02/28/personalise-or-perish---why-publishers-need-to-use-personalised-content","dateCreated":"2018-04-20T06:03:20.588Z","dateModified":"2018-04-20T06:03:20.588Z"}</script><script type="application/ld+json">{"@type":"Organization","@context":"http://schema.org","name":"Quintype","url":"http://www.quintype.com/","logo":"https://quintype.com/logo.png","sameAs":["https://www.facebook.com/quintype","https://twitter.com/quintype_inc","https://plus.google.com/+quintype","https://www.youtube.com/user/Quintype"]}</script><script type="application/ld+json">{"@type":"Organization","@context":"http://schema.org","author":[{"@type":"Person","givenName":"Greeshma","name":"Greeshma"}],"keywords":[],"url":"https://madrid.quintype.io/politics/2018/02/28/personalise-or-perish---why-publishers-need-to-use-personalised-content","dateCreated":"2018-04-20T06:03:20.588Z","dateModified":"2018-04-20T06:03:20.588Z","headline":"Personalise or perish - Why publishers need to use personalised content","alternativeHeadline":"","image":["images.assettype.com/quintype-demo/2018-03/a27aafbf-8a27-4f42-b78f-769eb04655d6/efa66751-e534-4a18-8ebe-e02189c356d9.jpg?w=480&auto=format%2Ccompress&fit=max"],"datePublished":"2018-04-20T06:03:25.102Z","description":"Personalised content marketing is the slayer weapon in this war for attention and engagement.","publisher":{"name":"Quintype","url":"http://www.quintype.com/","logo":"https://quintype.com/logo.png","sameAs":["https://www.facebook.com/quintype","https://twitter.com/quintype_inc","https://plus.google.com/+quintype","https://www.youtube.com/user/Quintype"]}}</script>', string);
+    });
+  });
+});
+
+
+
+describe('StructuredDataTags without news article data ', function() {
+  describe('On all pages', function() {
+    it("puts only the article tag when news-article is false in theme-attributes config", function() {
+      const seoConfig = {
+        generators: [StructuredDataTags],
+        structuredData: {
+          organization: {
+            name: "Quintype",
+            url: "http://www.quintype.com/",
+            logo: "https://quintype.com/logo.png",
+            sameAs: ["https://www.facebook.com/quintype","https://twitter.com/quintype_inc","https://plus.google.com/+quintype","https://www.youtube.com/user/Quintype"]
+          },
+          enableNewsArticle: false
+        }
+      };
+
+      const data = {
+        data : {
+          story: {
+            "seo": {
+              "meta-description": "",
+              "meta-title": " Why publishers need to use personalised content",
+              "meta-keywords": [],
+              "meta-google-news-standout": false,
+              "claim-reviews": {
+                "story": null
+              }
+            },
+            "author-name": "Greeshma",
+            "tags": [],
+            "headline": "Personalise or perish - Why publishers need to use personalised content",
+            "slug": "politics/2018/02/28/personalise-or-perish---why-publishers-need-to-use-personalised-content",
+            "last-published-at": 1524204205102,
+            "alternative": {
+              "home": {
+                "default": {
+                  "headline": "Personalise or perish"
+                }
+              }
+            },
+            "content-created-at": 1519814417485,
+            "owner-name": "Greeshma",
+            "hero-image-metadata": {
+              "width": 1920,
+              "height": 1280,
+              "mime-type": "image/jpeg",
+              "focus-point": [
+                931,
+                901
+              ]
+            },
+            "published-at": 1524204205102,
+            "summary": "Personalised content marketing is the slayer weapon in this war for attention and engagement.",
+            "hero-image-s3-key": "quintype-demo/2018-03/a27aafbf-8a27-4f42-b78f-769eb04655d6/efa66751-e534-4a18-8ebe-e02189c356d9.jpg",
+            "cards": [],
+            "content-updated-at": 1524204468980,
+            "first-published-at": 1519816264773,
+            "created-at": 1524204200588,
+            "updated-at": 1524204200588,
+            "authors": [
+              {
+                "id": 482995,
+                "name": "Greeshma",
+                "slug": "greeshma",
+                "avatar-url": "https://images.assettype.com/quintype-demo/2018-03/9a16b150-6281-45e6-bdb9-6eb1146e1a54/50b1da06-b478-4bc8-8067-fada337c55d0.jpeg",
+                "avatar-s3-key": "quintype-demo/2018-03/9a16b150-6281-45e6-bdb9-6eb1146e1a54/50b1da06-b478-4bc8-8067-fada337c55d0.jpeg",
+                "twitter-handle": null,
+                "bio": null
+              }
+            ],
+            "metadata": {
+              "card-share": {
+                "shareable": true
+              }
+            },
+            "publish-at": null,
+          },
+        },
+        config: {
+          "cdn-image": "images.assettype.com",
+          "sketches-host": "https://madrid.quintype.io",
+          "publisher-name": "quintype-demo",
+          "publisher-settings": {
+            "title": "Quintype Demo",
+            "copyright": "© quintype-demo 2018"
+          },
+          "social-links": {
+            "facebook-url": "https://www.facebook.com/quintypeinc",
+            "twitter-url": "https://twitter.com/quintype_inc"
+          },
+          "publisher-theme": {
+            "monogram": "",
+            "logo": "",
+            "primary_color": "#000",
+            "secondary_color": "",
+            "header_text_color": "",
+            "header_background_color": "",
+            "footer_text_color": "",
+            "footer_background_color": "",
+            "dfp_network_id": "60988533"
+          },
+          "theme-attributes": {
+            "monogram": "",
+            "logo": "",
+            "primary_color": "#000",
+            "secondary_color": "",
+            "header_text_color": "",
+            "header_background_color": "",
+            "footer_text_color": "",
+            "footer_background_color": "",
+            "dfp_network_id": "60988533",
+            "news-article": false
+          }
+        }
+      };
+
+      const string = getSeoMetadata(seoConfig, {}, 'home-page', data, {url: url.parse("/")});
+      assertContains('<script type="application/ld+json">{"@type":"Article","@context":"http://schema.org","author":[{"@type":"Person","givenName":"Greeshma","name":"Greeshma"}],"keywords":[],"url":"https://madrid.quintype.io/politics/2018/02/28/personalise-or-perish---why-publishers-need-to-use-personalised-content","dateCreated":"2018-04-20T06:03:20.588Z","dateModified":"2018-04-20T06:03:20.588Z"}</script><script type="application/ld+json">{"@type":"Organization","@context":"http://schema.org","name":"Quintype","url":"http://www.quintype.com/","logo":"https://quintype.com/logo.png","sameAs":["https://www.facebook.com/quintype","https://twitter.com/quintype_inc","https://plus.google.com/+quintype","https://www.youtube.com/user/Quintype"]}</script>', string);
+    });
   });
 });

--- a/test/structured_data_tags_test.js
+++ b/test/structured_data_tags_test.js
@@ -28,7 +28,7 @@ describe('StructuredDataTags', function() {
 
 describe('StructuredDataTags with news article data ', function() {
   describe('On all pages', function() {
-    it("puts the news article along with article tag when news-article is truthy in theme-attributes config", function() {
+    it("puts the news article along with article tag when structured_data_news_article is truthy in theme-attributes config", function() {
       const seoConfig = {
         generators: [StructuredDataTags],
         structuredData: {
@@ -116,28 +116,8 @@ describe('StructuredDataTags with news article data ', function() {
             "facebook-url": "https://www.facebook.com/quintypeinc",
             "twitter-url": "https://twitter.com/quintype_inc"
           },
-          "publisher-theme": {
-            "monogram": "",
-            "logo": "",
-            "primary_color": "#000",
-            "secondary_color": "",
-            "header_text_color": "",
-            "header_background_color": "",
-            "footer_text_color": "",
-            "footer_background_color": "",
-            "dfp_network_id": "60988533"
-          },
           "theme-attributes": {
-            "monogram": "",
-            "logo": "",
-            "primary_color": "#000",
-            "secondary_color": "",
-            "header_text_color": "",
-            "header_background_color": "",
-            "footer_text_color": "",
-            "footer_background_color": "",
-            "dfp_network_id": "60988533",
-            "news-article": true
+            "structured_data_news_article": true
           }
         }
       };
@@ -153,7 +133,7 @@ describe('StructuredDataTags with news article data ', function() {
 
 describe('StructuredDataTags without news article data ', function() {
   describe('On all pages', function() {
-    it("puts only the article tag when news-article is false in theme-attributes config", function() {
+    it("puts only the article tag when structured_data_news_article is false in theme-attributes config", function() {
       const seoConfig = {
         generators: [StructuredDataTags],
         structuredData: {
@@ -241,28 +221,11 @@ describe('StructuredDataTags without news article data ', function() {
             "facebook-url": "https://www.facebook.com/quintypeinc",
             "twitter-url": "https://twitter.com/quintype_inc"
           },
-          "publisher-theme": {
-            "monogram": "",
-            "logo": "",
-            "primary_color": "#000",
-            "secondary_color": "",
-            "header_text_color": "",
-            "header_background_color": "",
-            "footer_text_color": "",
-            "footer_background_color": "",
-            "dfp_network_id": "60988533"
-          },
           "theme-attributes": {
-            "monogram": "",
             "logo": "",
             "primary_color": "#000",
             "secondary_color": "",
-            "header_text_color": "",
-            "header_background_color": "",
-            "footer_text_color": "",
-            "footer_background_color": "",
-            "dfp_network_id": "60988533",
-            "news-article": false
+            "structured_data_news_article": false
           }
         }
       };


### PR DESCRIPTION
The publisher needs to set `structured_data_news_article` in `theme-attributes` of publisher configuration to enable  `NewsArticle` for each story

`Article` `ld+json` is enabled by default for each type of story