### PR TITLE
Added the title and the meta description for tag page

### DIFF
--- a/src/text-tags.js
+++ b/src/text-tags.js
@@ -42,6 +42,22 @@ function buildTagsFromStory(config, story, url = {}) {
   return storyMetaData;
 }
 
+function buildTagsFromTopic(config, data, url = {}) {
+
+  const topicUrl = `${config['sketches-host']}/topic/${data.tag}`;
+
+  const topicMetaData = {
+    "page-title":data.tagName,
+    description: data.tagDescription || data.tagName,
+    keywords: data.tagName,
+    canonicalUrl: topicUrl,
+    ogUrl: topicUrl,
+    ogTitle: data.tagName,
+    ogDescription: data.tagDescription || data.tagName
+  };
+
+  return topicMetaData;
+}
 
 function buildCustomTags(customTags = {}, pageType = ''){
   const configObject = customTags[pageType];
@@ -78,6 +94,7 @@ function getSeoData(config, pageType, data, url = {}, seoConfig = {}) {
   switch(pageType) {
     case 'home-page': return findRelevantConfig(page => page['owner-type'] === 'home')
     case 'section-page': return findRelevantConfig(page => page['owner-type'] === 'section' && page['owner-id'] === get(data, ['data', 'section', 'id'])) || getSeoData(config, 'home-page', data, url);
+    case 'tag-page': return buildTagsFromTopic(config, get(data, ["data"]), url) || getSeoData(config, "home-page", data, url);
     case 'story-page': return buildTagsFromStory(config, get(data, ["data", "story"]), url) || getSeoData(config, "home-page", data, url);
     default: return getSeoData(config, 'home-page', data, url);
   }

--- a/src/text-tags.js
+++ b/src/text-tags.js
@@ -43,8 +43,7 @@ function buildTagsFromStory(config, story, url = {}) {
 }
 
 function buildTagsFromTopic(config, tag, url = {}) {
-  console.log('tag', tag);
-  console.log('url', url);
+
   if(!tag)
     return;
 

--- a/src/text-tags.js
+++ b/src/text-tags.js
@@ -42,18 +42,22 @@ function buildTagsFromStory(config, story, url = {}) {
   return storyMetaData;
 }
 
-function buildTagsFromTopic(config, data, url = {}) {
+function buildTagsFromTopic(config, tag, url = {}) {
+  console.log('tag', tag);
+  console.log('url', url);
+  if(!tag)
+    return;
 
-  const topicUrl = `${config['sketches-host']}/topic/${data.tag}`;
+  const topicUrl = `${config['sketches-host']}${url.pathname}`;
 
   const topicMetaData = {
-    "page-title":data.tagName,
-    description: data.tagDescription || data.tagName,
-    keywords: data.tagName,
+    "page-title":tag.name,
+    description: tag.description || tag.name,
+    keywords: tag.name,
     canonicalUrl: topicUrl,
     ogUrl: topicUrl,
-    ogTitle: data.tagName,
-    ogDescription: data.tagDescription || data.tagName
+    ogTitle: tag.name,
+    ogDescription: tag.tagDescription || tag.name
   };
 
   return topicMetaData;
@@ -94,7 +98,7 @@ function getSeoData(config, pageType, data, url = {}, seoConfig = {}) {
   switch(pageType) {
     case 'home-page': return findRelevantConfig(page => page['owner-type'] === 'home')
     case 'section-page': return findRelevantConfig(page => page['owner-type'] === 'section' && page['owner-id'] === get(data, ['data', 'section', 'id'])) || getSeoData(config, 'home-page', data, url);
-    case 'tag-page': return buildTagsFromTopic(config, get(data, ["data"]), url) || getSeoData(config, "home-page", data, url);
+    case 'tag-page': return buildTagsFromTopic(config, get(data, ["data", "tag"]), url) || getSeoData(config, "home-page", data, url);
     case 'story-page': return buildTagsFromStory(config, get(data, ["data", "story"]), url) || getSeoData(config, "home-page", data, url);
     default: return getSeoData(config, 'home-page', data, url);
   }

--- a/src/text-tags.js
+++ b/src/text-tags.js
@@ -44,7 +44,7 @@ function buildTagsFromStory(config, story, url = {}) {
 
 function buildTagsFromTopic(config, tag, url = {}) {
 
-  if(!tag)
+  if(isEmpty(tag))
     return;
 
   const topicUrl = `${config['sketches-host']}${url.pathname}`;


### PR DESCRIPTION
For the ticket https://github.com/quintype/ace-support/issues/113, All topic(tag) pages give the same title and description.