### PR TITLE
feat(author-page): Add support for custom author-page seo data

### DIFF
--- a/src/text-tags.js
+++ b/src/text-tags.js
@@ -61,20 +61,21 @@ function buildTagsFromTopic(config, tag, url = {}) {
 }
 
 function buildTagsFromAuthor(config, author, url = {}) {
-  const authorUrl = `${config['sketches-host']}${url.path}`;
+  const authorName = author.name;
+  const authorUrl = `${config['sketches-host']}/author/${author.id}`;
   const publisherName = config['publisher-name'];
   const description = author.bio || `View all articles written by ${author.name} on ${publisherName}`;
 
   if(isEmpty(author)) return;
 
   return {
-    title: author.name,
-    "page-title": author.name,
+    title: authorName,
+    "page-title": authorName,
     description: description,
-    keywords: `${author.name},${publisherName}`,
+    keywords: `${authorName},${publisherName}`,
     canonicalUrl: authorUrl,
     ogUrl: authorUrl,
-    ogTitle: author.name,
+    ogTitle: authorName,
     ogDescription: description,
   };
 }

--- a/src/text-tags.js
+++ b/src/text-tags.js
@@ -61,12 +61,12 @@ function buildTagsFromTopic(config, tag, url = {}) {
 }
 
 function buildTagsFromAuthor(config, author, url = {}) {
+  if(isEmpty(author)) return;
+
   const authorName = author.name;
   const authorUrl = `${config['sketches-host']}/author/${author.id}`;
   const publisherName = config['publisher-name'];
   const description = author.bio || `View all articles written by ${author.name} on ${publisherName}`;
-
-  if(isEmpty(author)) return;
 
   return {
     title: authorName,

--- a/src/text-tags.js
+++ b/src/text-tags.js
@@ -60,6 +60,25 @@ function buildTagsFromTopic(config, tag, url = {}) {
   return topicMetaData;
 }
 
+function buildTagsFromAuthor(config, author, url = {}) {
+  const authorUrl = `${config['sketches-host']}${url.path}`;
+  const publisherName = config['publisher-name'];
+  const description = author.bio || `View all articles written by ${author.name} on ${publisherName}`;
+
+  if(isEmpty(author)) return;
+
+  return {
+    title: author.name,
+    "page-title": author.name,
+    description: description,
+    keywords: `${author.name},${publisherName}`,
+    canonicalUrl: authorUrl,
+    ogUrl: authorUrl,
+    ogTitle: author.name,
+    ogDescription: description,
+  };
+}
+
 function buildCustomTags(customTags = {}, pageType = ''){
   const configObject = customTags[pageType];
   if(configObject) {
@@ -97,6 +116,7 @@ function getSeoData(config, pageType, data, url = {}, seoConfig = {}) {
     case 'section-page': return findRelevantConfig(page => page['owner-type'] === 'section' && page['owner-id'] === get(data, ['data', 'section', 'id'])) || getSeoData(config, 'home-page', data, url);
     case 'tag-page': return buildTagsFromTopic(config, get(data, ["data", "tag"]), url) || getSeoData(config, "home-page", data, url);
     case 'story-page': return buildTagsFromStory(config, get(data, ["data", "story"]), url) || getSeoData(config, "home-page", data, url);
+    case 'author-page': return buildTagsFromAuthor(config, get(data, ["data", "author"], {}), url) || getSeoData(config, "home-page", data, url);
     default: return getSeoData(config, 'home-page', data, url);
   }
 }

--- a/src/text-tags.js
+++ b/src/text-tags.js
@@ -64,7 +64,7 @@ function buildTagsFromAuthor(config, author, url = {}) {
   if(isEmpty(author)) return;
 
   const authorName = author.name;
-  const authorUrl = `${config['sketches-host']}/author/${author.id}`;
+  const authorUrl = `${config['sketches-host']}${url.pathname}`;
   const publisherName = config['publisher-name'];
   const description = author.bio || `View all articles written by ${author.name} on ${publisherName}`;
 


### PR DESCRIPTION
We didn't have the support for meta-tags on the author page to pick up author data, they were picking up data from our home-page. As per this PR, the support has been added for the author-page meta-tags to pick up actual author data instead.