### PR TITLE
fix(null cover-image): return default value in case of null

### DIFF
--- a/src/image-tags.js
+++ b/src/image-tags.js
@@ -13,7 +13,7 @@ function pickImageFromStory(story) {
 }
 
 function pickImageFromCollection(collection) {
-  const coverImage = get(collection, ["metadata", "cover-image"], {});
+  const coverImage = get(collection, ["metadata", "cover-image"]) || {};
   if(!coverImage["cover-image-s3-key"])
     return;
 


### PR DESCRIPTION
#### issue:
getting error(cannot read property `cover-image-s3-key` of `null`) when api returns `cover-image` as `null`

#### solution:
return default value in case of null too.