### PR TITLE
fix(Put ampStoryPages key back): Put ampStoryPages key back for amp check

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ new SEO({
       sameAs: ["https://www.facebook.com/quintype","https://twitter.com/quintype_in","https://plus.google.com/+quintype","https://www.youtube.com/user/Quintype"],
     },
     enableNewsArticle: true
-  }
+  },
+  ampStoryPages: true
 });
 ```
 
@@ -65,8 +66,8 @@ To generate the Entity Tags, while executing getMetaTags on the SEO instance, th
     ]
   }
 ```
-data Object should have a key called "linkedEntities" and the value should be an array of all Entities. 
-Please also refer to the test case "Structured DataTags for Entity" in structured_data_tags_test 
+data Object should have a key called "linkedEntities" and the value should be an array of all Entities.
+Please also refer to the test case "Structured DataTags for Entity" in structured_data_tags_test
 
 ### Structured data
 
@@ -85,7 +86,7 @@ structuredData: {
 
 #### Organization
 
-Sample object: 
+Sample object:
 ```
 organization: {
     name: 'Bloomberg Quint',
@@ -101,7 +102,7 @@ organization: {
   }
 ```
 #### website
-Sample object: 
+Sample object:
 ```
 website: {
     url: 'https://www.bloombergquint.com/',

--- a/src/amp-tags.js
+++ b/src/amp-tags.js
@@ -9,7 +9,7 @@ function storyPageAmpTags(story) {
 }
 
 export function StoryAmpTags(seoConfig, config, pageType, data, opts) {
-  if(pageType == 'story-page' && get(data, ["data", "story", "is-amp-supported"]))
+  if(pageType == 'story-page' && seoConfig.ampStoryPages && get(data, ["data", "story", "is-amp-supported"]))
     return storyPageAmpTags(get(data, ["data", "story"]))
   else
     return []

--- a/test/amp_tags_test.js
+++ b/test/amp_tags_test.js
@@ -5,7 +5,8 @@ const assert = require('assert');
 
 describe('ImageTags', function() {
   const seoConfig = {
-    generators: [StoryAmpTags]
+    generators: [StoryAmpTags],
+    ampStoryPages: true
   }
 
   const config = {


### PR DESCRIPTION
Got an update that `is-amp-supported` key which sketches gives us in the story's data is different from the `ampStoryPages` key that we provide from the app to enable/disable amp