### PR TITLE
Added a convenient way to override tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import {omit, flatMap, get} from "lodash";
+import {omit, flatMap, get, uniqBy} from "lodash";
 import React from "react";
 import ReactDomServer from"react-dom/server";
 
@@ -12,13 +12,23 @@ import {generateStaticData, generateStructuredData} from './src/generate-common-
 
 export {TextTags, StaticTags, AuthorTags, ImageTags, StructuredDataTags, StoryAmpTags, generateStaticData, generateStructuredData};
 
+function tagToKey(tag) {
+  switch(tag.tag || "meta") {
+    case "meta": return `meta-${tag.name || "name"}-${tag.property || "property"}`;
+    case "link": return `link-${tag.rel}`;
+    case "title": return `title`;
+    default: return Math.random().toString();
+  }
+}
+
 export class MetaTagList {
   constructor(tags) {
     this.tags = tags;
   }
 
   toString() {
-    return ReactDomServer.renderToStaticMarkup(this.tags.map(tag => React.createElement(tag.tag || "meta", omit(tag, "tag"))))
+    const uniqueTags = uniqBy(this.tags.reverse(), tagToKey).reverse();
+    return ReactDomServer.renderToStaticMarkup(uniqueTags.map(tag => React.createElement(tag.tag || "meta", omit(tag, "tag"))))
   }
 
   addTag() {
@@ -78,7 +88,7 @@ export class SEO {
    * Create a new SEO Object
    * @param {Object} seoConfig Configuration that is passed as the first argument to each {@link Generator}
    * @param {Array<Generator>} seoConfig.generators List of generators to run (optional)
-   * @param {Array<Generator>} seoConfig.extraGenerators List of generators to run after the main generators run
+   * @param {Array<Generator>} seoConfig.extraGenerators List of generators to run after the main generators run. Generators here can override tags that are returned by earlier generator. See [Custom SEO Malibu Tutorial](https://developers.quintype.com/malibu/tutorial/custom-seo).
    * @param {Object} seoConfig.pageTypeAliases A map of aliases to their original page type. This is a convenience if you want to have a different page type for some sections. ex: `{"budget-page":"section-page"}`
    */
   constructor(seoConfig = {}) {

--- a/test/meta_tags_list_test.js
+++ b/test/meta_tags_list_test.js
@@ -1,0 +1,37 @@
+const { MetaTagList } = require("..");
+
+const assert = require('assert');
+
+describe('MetaTagList', function () {
+  it("serializes tags to string", () => {
+    const tags = new MetaTagList([
+      {tag: "title", children: "Foobar"},
+      {tag: "link", rel: "canonical", href: "http://foo.bar"},
+      {name: "something", value: "somevalue"}
+    ])
+    assert.equal(tags.toString(), '<title>Foobar</title><link rel="canonical" href="http://foo.bar"/><meta name="something" value="somevalue"/>');
+  })
+
+  context("overriding tags", () => {
+    const commonTags = [
+      { tag: "title", children: "Foobar" },
+      { tag: "link", rel: "canonical", href: "http://foo.bar" },
+      { name: "something", value: "somevalue" }
+    ];
+
+    it("can override the title tag", () => {
+      const tags = new MetaTagList([...commonTags, {tag: "title", children: "New Title"}]);
+      assert.equal(tags.toString(), '<link rel="canonical" href="http://foo.bar"/><meta name="something" value="somevalue"/><title>New Title</title>');
+    });
+
+    it("can override a link tag", () => {
+      const tags = new MetaTagList([...commonTags, { tag: "link", rel: 'canonical', href: "http://foo.baz" }]);
+      assert.equal(tags.toString(), '<title>Foobar</title><meta name="something" value="somevalue"/><link rel="canonical" href="http://foo.baz"/>');
+    });
+
+    it("can override a meta tag", () => {
+      const tags = new MetaTagList([...commonTags, { name: "something", value: "somevalue2" }]);
+      assert.equal(tags.toString(), '<title>Foobar</title><link rel="canonical" href="http://foo.bar"/><meta name="something" value="somevalue2"/>');
+    })
+  })
+});


### PR DESCRIPTION
Here is the associated Documentation:

Most common requirements for SEO optimization are handled by [@quintype/seo](https://developers.quintype.com/quintype-node-seo/). However, it is possible to override parts of the behavior.

In our malibu app, a default set of SEO implementation containing the basic structured data and static tags can be found in `app/server/app.js`.

```javascript
isomorphicRoutes(app, {
    ...
  seo: new SEO({
    staticTags: {...},
    enableTwitterCards: true,
    enableOgTags: true,
    enableNews: true,
    structuredData: {...}
  })
});
```

## Adding a new generator

The custom SEO logic can be added by creating a custom [Generator](https://developers.quintype.com/quintype-node-seo/global.html#Generator), which runs after the standard generators.

Lets say we want to override the value of the *"twitter:creator"* tag. By default, this meta tag will have it's value set as the author of the story, but let's set it to the name of the publication.

Let's first create the generator. For simplicity, we will just add the generator in *app/server/app.js*.

```javascript
function MyGenerator(seoConfig, config, pageType, data, opts) {
  if(pageType === 'story') {
    const story = data.story; // ignored
    return [{tag: "meta", name: "twitter:creator", content: "My Journal"}]
  } else {
    return [];
  }
}
```

Each of the items returned by the generator will return a tag that gets converted to HTML tag.

Let's now add this generator to our SEO class

```javascript
isomorphicRoutes(app, {
    ...
  seo: new SEO({
    ...
    extraGenerators: [MyGenerator]
  })
});
```

Opening up any story page, you should see the tag taking the new value.