### PR TITLE
Make AMP URL absolute based on the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.35.1](https://github.com/quintype/quintype-node-seo/compare/v1.35.1-amp-absolute.0...v1.35.1) (2020-03-11)
+
 ## [1.35.0](https://github.com/quintype/quintype-node-seo/compare/v1.35.0-thumbnail.2...v1.35.0) (2020-03-10)
 
 ### [1.34.3](https://github.com/quintype/quintype-node-seo/compare/v1.34.1...v1.34.3) (2020-03-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.36.0](https://github.com/quintype/quintype-node-seo/compare/v1.35.1...v1.36.0) (2020-03-11)
+
+
+### Features
+
+* add `appendHostToAmpUrl` to make AMPUrl (`rel="amphtml"`) absolute. ([9814d7b](https://github.com/quintype/quintype-node-seo/commit/9814d7b6c90d39aa75f974cb8d3418360badd31e))
+
 ### [1.35.1](https://github.com/quintype/quintype-node-seo/compare/v1.35.1-amp-absolute.0...v1.35.1) (2020-03-11)
 
 ## [1.35.0](https://github.com/quintype/quintype-node-seo/compare/v1.35.0-thumbnail.2...v1.35.0) (2020-03-10)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.35.1-amp-absolute.0",
+  "version": "1.35.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.35.0",
+  "version": "1.35.1-amp-absolute.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2366,7 +2366,7 @@
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -2376,7 +2376,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -2406,7 +2406,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -2962,7 +2962,7 @@
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
@@ -3010,7 +3010,7 @@
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
@@ -3028,7 +3028,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -3262,7 +3262,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.35.1",
+  "version": "1.36.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "coverage": "nyc --all --reporter=html npm test",
     "docs": "rimraf docs && jsdoc -c jsdoc.json",
     "prepack": "npm run build",
+    "prepublishOnly": "npm install && npm test && ./bin-dev-scripts/standard-version-release.sh",
     "test": "npm run build && mocha test",
     "sync-files-to": "npx onchange --verbose --await-write-finish=2000 'src/**/*' -- ./bin-dev-scripts/sync-to.sh "
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.35.0",
+  "version": "1.35.1-amp-absolute.0",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.35.1-amp-absolute.0",
+  "version": "1.35.1",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.35.1",
+  "version": "1.36.0",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",
@@ -16,7 +16,6 @@
     "coverage": "nyc --all --reporter=html npm test",
     "docs": "rimraf docs && jsdoc -c jsdoc.json",
     "prepack": "npm run build",
-    "prepublishOnly": "npm install && npm test && ./bin-dev-scripts/standard-version-release.sh",
     "test": "npm run build && mocha test",
     "sync-files-to": "npx onchange --verbose --await-write-finish=2000 'src/**/*' -- ./bin-dev-scripts/sync-to.sh "
   },

--- a/src/amp-tags.js
+++ b/src/amp-tags.js
@@ -31,7 +31,7 @@ export function StoryAmpTags(seoConfig, config, pageType, data, opts) {
     return [{
       tag: 'link',
       rel: 'amphtml',
-      href: `/amp/story/${encodeURIComponent(story.slug)}`
+      href: `${config['sketches-host']}/amp/story/${encodeURIComponent(story.slug)}`
     }];
   } else {
     return [];

--- a/src/amp-tags.js
+++ b/src/amp-tags.js
@@ -27,11 +27,15 @@ function showAmpTag({ampStoryPages = true}, pageType, story) {
  */
 export function StoryAmpTags(seoConfig, config, pageType, data, opts) {
   const story = get(data, ["data", "story"], {});
+  console.log(seoConfig, config);
+  
+  // TODO: Remove this condition and always make absolute URL if that's better for AMP discoverability.
+  const ampUrlAppend = seoConfig.appendHostToAmpUrl ? config['sketches-host'] : ''
   if(showAmpTag(seoConfig, pageType, story)) {
     return [{
       tag: 'link',
       rel: 'amphtml',
-      href: `${config['sketches-host']}/amp/story/${encodeURIComponent(story.slug)}`
+      href: `${ampUrlAppend}/amp/story/${encodeURIComponent(story.slug)}`
     }];
   } else {
     return [];

--- a/src/amp-tags.js
+++ b/src/amp-tags.js
@@ -27,8 +27,6 @@ function showAmpTag({ampStoryPages = true}, pageType, story) {
  */
 export function StoryAmpTags(seoConfig, config, pageType, data, opts) {
   const story = get(data, ["data", "story"], {});
-  console.log(seoConfig, config);
-  
   // TODO: Remove this condition and always make absolute URL if that's better for AMP discoverability.
   const ampUrlAppend = seoConfig.appendHostToAmpUrl ? config['sketches-host'] : ''
   if(showAmpTag(seoConfig, pageType, story)) {

--- a/test/amp_tags_test.js
+++ b/test/amp_tags_test.js
@@ -10,6 +10,7 @@ describe('ImageTags', function() {
   }
 
   const config = {
+    'sketches-host': 'https://madrid.quintype.io'
   }
 
   it("gets amp tags for supported stories", function() {
@@ -35,5 +36,17 @@ describe('ImageTags', function() {
     assert.equal('<link rel="amphtml" href="/amp/story/section%2Fslug"/>', publicStoryResults);
     const privateStoryResults = getSeoMetadata({ ...seoConfig, ampStoryPages: "public" }, config, 'story-page', { data: { story: {...story, access: "subscription"} } }, {})
     assert.equal('', privateStoryResults);
+  })
+  
+  it("does not append domain to amp stories if appendHostToAmpUrl not present", function () {
+    const story = {"slug": "section/slug", "is-amp-supported": true}
+    const string = getSeoMetadata(seoConfig, config, 'story-page', {data: {story: story}}, {})
+    assertContains('<link rel="amphtml" href="/amp/story/section%2Fslug"/>', string);
+  })
+
+  it("does append domain to amp stories if appendHostToAmpUrl present", function () {
+    const story = {"slug": "section/slug", "is-amp-supported": true}
+    const string = getSeoMetadata({...seoConfig, appendHostToAmpUrl: true}, config, 'story-page', {data: {story: story}}, {})
+    assertContains('<link rel="amphtml" href="https://madrid.quintype.io/amp/story/section%2Fslug"/>', string);
   })
 });


### PR DESCRIPTION
Based on https://acceleratedmobilepageurl.googleapis.com/v1/ampUrls:batchGet api response, if `rel="amphtml"` is not an absolute URL, google seems to be considering it an Error with response:
```
{
  "urlErrors": [
    {
      "errorCode": "URL_IS_INVALID_AMP",
      "errorMessage": "Request URL is an invalid AMP URL.",
      "originalUrl": "https://lonely-part.surge.sh"
    }
  ]
}
```
I didn't move every AMP to absolute in this PR, but made it configurable, so that it will be easy to move. Once this hypothesis is proved we can remove the toggle altogether also.


A sample curl request:
```
curl 'https://acceleratedmobilepageurl.googleapis.com/v1/ampUrls:batchGet?key=AIzaSyA4Ron_KRYJuQzRze-LgnqCNCnUkK764i4' -H 'authority: acceleratedmobilepageurl.googleapis.com' -H 'pragma: no-cache' -H 'cache-control: no-cache' -H 'dnt: 1' -H 'accept-language: en-US,en;q=0.9,ml;q=0.8' -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36' -H 'content-type: text/plain;charset=UTF-8' -H 'accept: */*' -H 'sec-fetch-dest: empty' -H 'x-client-data: CI+2yQEIpbbJAQjEtskBCKmdygEIt6rKAQjLrsoBCNCvygEIvbDKAQiXtcoBCJq1ygEI7bXKAQiOusoBCLC9ygEI5cbKAQjnxsoBGLu6ygE=' -H 'origin: https://developers.google.com' -H 'sec-fetch-site: cross-site' -H 'sec-fetch-mode: cors' -H 'referer: https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fwww.barandbench.com%2Finterviews%2Fsupreme-court-was-faced-with-a-balancing-act-ashim-sood-on-the-cryptocurrency-judgment-watch-video?sda' --data-binary '{"urls":["https://shrill-acoustics.surge.sh"],"lookupStrategy":"FETCH_LIVE_DOC"}' --compressed
```