### PR TITLE
fix: generate canonical url pointing to the amp page if it is a visua…

### DIFF
--- a/src/text-tags.js
+++ b/src/text-tags.js
@@ -47,6 +47,10 @@ function buildTagsFromStory(config, story, url = {}, data = {}) {
     author: authors
   };
 
+  if (story["story-template"] === "visual-story") {
+    storyMetaData.canonicalUrl = `/amp/story/${story.slug}`
+  }
+
   if (url.query && url.query.cardId) {
     const storyCardMetadata = getStoryCardMetadata(url.query.cardId);
     return Object.assign({}, storyMetaData, storyCardMetadata); //TODO rewrite in spread syntax, add babel plugin

--- a/test/text_tags_test.js
+++ b/test/text_tags_test.js
@@ -500,10 +500,6 @@ describe('TextTags', function () {
       }
       const story = { headline: "Foobar", "story-template": "visual-story", summary: "Some Foobar", tags: [{ name: "Footag" }], slug: "politics/awesome", authors: [{ 'name': "foo" }] }
       const string = getSeoMetadata(seoConfig, { "sketches-host": "http://foo.com" }, 'story-page', { data: { story: story } }, { url: url.parse("/my-page") })
-      // assertContains('<title>Foobar</title>', string);
-      // assertContains('<meta name="title" content="Foobar"/>', string);
-      // assertContains('<meta name="description" content="Some Foobar"/>', string);
-      // assertContains('<meta name="keywords" content="Footag"/>', string);
       assertContains('<link rel="canonical" href="/amp/story/politics/awesome"/>', string);
     });
   });

--- a/test/text_tags_test.js
+++ b/test/text_tags_test.js
@@ -241,32 +241,7 @@ describe('TextTags', function () {
         assertDoesNotContains('description', string);
       });
     })
-
-
-
-
-
   });
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
   describe('Story Page', function () {
     it("Generates SEO tags for a story page", function () {
@@ -303,8 +278,6 @@ describe('TextTags', function () {
       assertContains('<meta name="keywords" content="Footag"/>', string);
       assertContains('<link rel="canonical" href="http://foo.com/politics/awesome"/>', string);
     });
-
-
 
     it("Generates SEO tags for a card in story page", function () {
       const seoConfig = {
@@ -490,9 +463,6 @@ describe('TextTags', function () {
       assertContains('<link rel="canonical" href="http://foo.com/politics/awesome"/>', string);
     });
 
-
-
-
     it("Overrides the canonical url", function () {
       const seoConfig = {
         generators: [TextTags],
@@ -522,6 +492,19 @@ describe('TextTags', function () {
       const string = getSeoMetadata(seoConfig, { "sketches-host": "http://foo.com" }, 'story-page', { data: { story: story } }, { url: url.parse("/my-page") })
       assertContains('<meta name="news_keywords" content="Footag"/>', string);
       assertContains('<link rel="standout" href="http://foo.com/politics/awesome"/>', string);
+    });
+
+    it("Generates canonical URL pointing to the amp page if it is a visual story", function () {
+      const seoConfig = {
+        generators: [TextTags],
+      }
+      const story = { headline: "Foobar", "story-template": "visual-story", summary: "Some Foobar", tags: [{ name: "Footag" }], slug: "politics/awesome", authors: [{ 'name': "foo" }] }
+      const string = getSeoMetadata(seoConfig, { "sketches-host": "http://foo.com" }, 'story-page', { data: { story: story } }, { url: url.parse("/my-page") })
+      // assertContains('<title>Foobar</title>', string);
+      // assertContains('<meta name="title" content="Foobar"/>', string);
+      // assertContains('<meta name="description" content="Some Foobar"/>', string);
+      // assertContains('<meta name="keywords" content="Footag"/>', string);
+      assertContains('<link rel="canonical" href="/amp/story/politics/awesome"/>', string);
     });
   });
 


### PR DESCRIPTION
…l story

# Description

For context about the issue, please refer https://github.com/quintype/quintype-node-seo/issues/328

Fixes # (issue-reference)

Dependencies # (dependency-issue-reference)

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added test to check if SEO generates canonical URL pointing to the amp page if it is a visual story

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
