### PR TITLE
feat(News Article Schema): support enableNewsArticle prop from config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.38.40",
+  "version": "1.38.41-news-article-schema.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3950,7 +3950,7 @@
     },
     "fs-access": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
@@ -4281,7 +4281,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -4722,7 +4722,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -7980,7 +7980,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.38.41-news-article-schema.0",
+  "version": "1.38.41-news-article-schema.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3950,7 +3950,7 @@
     },
     "fs-access": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
@@ -4281,7 +4281,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -4722,7 +4722,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -7980,7 +7980,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.38.41-news-article-schema.0",
+  "version": "1.38.41-news-article-schema.1",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.38.40",
+  "version": "1.38.41-news-article-schema.0",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/src/generate-common-seo.js
+++ b/src/generate-common-seo.js
@@ -1,6 +1,6 @@
-import omitBy from 'lodash/omitBy';
-import isUndefined from 'lodash/isUndefined';
 import get from 'lodash/get';
+import isUndefined from 'lodash/isUndefined';
+import omitBy from 'lodash/omitBy';
 import { getQueryParams } from "./utils";
 
 export function getTitle(config) {
@@ -48,9 +48,12 @@ export function generateStructuredData(config = {}) {
   const { "theme-attributes":themeConfig, "social-links":socialLinks, "seo-metadata":seoMetadata = [] } = config;
   const homePageSeo = seoMetadata.find(page => page["owner-type"] === "home") || {};
   const { "page-title":pageTitle = "", description = "", keywords  =  "" } = get(homePageSeo, ["data"], {});
-
+  let enableNewsArticle = themeConfig['structured_data_news_article'];
   if(!themeConfig || !themeConfig.logo) {
     return {};
+  }
+  if(config.hasOwnProperty('enableNewsArticle')){
+    enableNewsArticle = config.enableNewsArticle;
   }
 
   return {
@@ -60,8 +63,8 @@ export function generateStructuredData(config = {}) {
       logo: generateImageObject(config),
       sameAs: socialLinks ? Object.values(socialLinks) : []
     },
-		enableNewsArticle: !!themeConfig['structured_data_news_article'],
-		storyUrlAsMainEntityUrl: !!themeConfig['structured_data_news_article'],
+		enableNewsArticle: !!enableNewsArticle,
+		storyUrlAsMainEntityUrl: !!enableNewsArticle,
     enableVideo: !themeConfig['structured_data_enable_video'],
     enableLiveBlog: !themeConfig['structured_data_enable_live_blog'],
     website: {

--- a/src/generate-common-seo.js
+++ b/src/generate-common-seo.js
@@ -52,8 +52,8 @@ export function generateStructuredData(config = {}) {
   if(!themeConfig || !themeConfig.logo) {
     return {};
   }
-  if(config.hasOwnProperty('enableNewsArticle') && typeof config.enableNewsArticle !== "undefined"){
-    enableStructuredDataForNewsArticle = config.enableNewsArticle;
+  if(config.hasOwnProperty('enableStructuredDataForNewsArticle') && typeof config.enableStructuredDataForNewsArticle !== "undefined"){
+    enableStructuredDataForNewsArticle = config.enableStructuredDataForNewsArticle;
   }
 
   return {

--- a/src/generate-common-seo.js
+++ b/src/generate-common-seo.js
@@ -48,12 +48,12 @@ export function generateStructuredData(config = {}) {
   const { "theme-attributes":themeConfig, "social-links":socialLinks, "seo-metadata":seoMetadata = [] } = config;
   const homePageSeo = seoMetadata.find(page => page["owner-type"] === "home") || {};
   const { "page-title":pageTitle = "", description = "", keywords  =  "" } = get(homePageSeo, ["data"], {});
-  let enableNewsArticle = themeConfig['structured_data_news_article'];
+  let enableStructuredDataForNewsArticle = themeConfig['structured_data_news_article'];
   if(!themeConfig || !themeConfig.logo) {
     return {};
   }
-  if(config.hasOwnProperty('enableNewsArticle')){
-    enableNewsArticle = config.enableNewsArticle;
+  if(config.hasOwnProperty('enableNewsArticle') && typeof config.enableNewsArticle !== "undefined"){
+    enableStructuredDataForNewsArticle = config.enableNewsArticle;
   }
 
   return {
@@ -63,8 +63,8 @@ export function generateStructuredData(config = {}) {
       logo: generateImageObject(config),
       sameAs: socialLinks ? Object.values(socialLinks) : []
     },
-		enableNewsArticle: !!enableNewsArticle,
-		storyUrlAsMainEntityUrl: !!enableNewsArticle,
+		enableNewsArticle: !!enableStructuredDataForNewsArticle,
+		storyUrlAsMainEntityUrl: !!enableStructuredDataForNewsArticle,
     enableVideo: !themeConfig['structured_data_enable_video'],
     enableLiveBlog: !themeConfig['structured_data_enable_live_blog'],
     website: {

--- a/src/generate-common-seo.js
+++ b/src/generate-common-seo.js
@@ -48,10 +48,10 @@ export function generateStructuredData(config = {}) {
   const { "theme-attributes":themeConfig, "social-links":socialLinks, "seo-metadata":seoMetadata = [] } = config;
   const homePageSeo = seoMetadata.find(page => page["owner-type"] === "home") || {};
   const { "page-title":pageTitle = "", description = "", keywords  =  "" } = get(homePageSeo, ["data"], {});
-  let enableStructuredDataForNewsArticle = themeConfig['structured_data_news_article'];
   if(!themeConfig || !themeConfig.logo) {
     return {};
   }
+  let enableStructuredDataForNewsArticle = themeConfig['structured_data_news_article'] || false;
   if(config.hasOwnProperty('enableStructuredDataForNewsArticle') && typeof config.enableStructuredDataForNewsArticle !== "undefined"){
     enableStructuredDataForNewsArticle = config.enableStructuredDataForNewsArticle;
   }


### PR DESCRIPTION
# Description

Created a new key in config to support the PB based toggle for News Article Schema

Fixes https://github.com/quintype/page-builder/issues/1459

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test Case A
- [ ] Test Case B


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
