### PR TITLE
Feat(ImageTags): Added support for og:image:alt and twitter:image:alt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.38.37-image-alt-tag.0",
+  "version": "1.38.37-image-alt-tag.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2074,7 +2074,7 @@
     },
     "callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
@@ -7268,7 +7268,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.38.36",
+  "version": "1.38.37-image-alt-tag.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.38.37-image-alt-tag.0",
+  "version": "1.38.37-image-alt-tag.1",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.38.36",
+  "version": "1.38.37-image-alt-tag.0",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/src/image-tags.js
+++ b/src/image-tags.js
@@ -1,59 +1,70 @@
-import { get, isEmpty } from 'lodash';
-import { FocusedImage } from 'quintype-js';
+import { get, isEmpty } from "lodash";
+import { FocusedImage } from "quintype-js";
 
 function pickImageFromCard(story, cardId) {
-  const { metadata = {} } = story.cards.find(card => card.id === cardId) || {};
-  if(metadata && !isEmpty(metadata) && get(metadata, ['social-share', 'image', 'key'], false)) {
-    const alt = metadata['social-share'].image.attribution || undefined;
-    return {image: new FocusedImage(metadata['social-share'].image.key, metadata['social-share'].image.metadata || {}), alt};
+  const { metadata = {} } = story.cards.find((card) => card.id === cardId) || {};
+  if (metadata && !isEmpty(metadata) && get(metadata, ["social-share", "image", "key"], false)) {
+    const alt = metadata["social-share"].image.attribution || getAltribution(story);
+    return {
+      image: new FocusedImage(metadata["social-share"].image.key, metadata["social-share"].image.metadata || {}),
+      alt,
+    };
   }
 }
 
+function getAltribution(story) {
+  return (
+    story["hero-image-attribution"] ||
+    story.summary ||
+    get(story, ["alternative", "home", "default", "headline"]) ||
+    story.headline
+  );
+}
+
 function pickImageFromStory(story) {
+  function getAlternateProperties(type, key) {
+    return get(story, ["alternative", `${type}`, "default", "hero-image", `${key}`]);
+  }
 
-  function getAlternateProperties (type, key) {
-    return get(story, ["alternative", `${type}`, "default", "hero-image", `${key}`]) ;
-   }
+  const alternateSocialMetadata = getAlternateProperties("social", "hero-image-metadata");
+  const alternateHomeMetadata = getAlternateProperties("home", "hero-image-metadata");
+  const alternateHomeS3Key = getAlternateProperties("home", "hero-image-s3-key");
+  const alternateSocialS3Key = getAlternateProperties("social", "hero-image-s3-key");
 
-   const alternateSocialMetadata = getAlternateProperties("social", "hero-image-metadata");
-   const alternateHomeMetadata = getAlternateProperties("home", "hero-image-metadata");
-   const alternateHomeS3Key = getAlternateProperties("home", "hero-image-s3-key");
-   const alternateSocialS3Key = getAlternateProperties("social", "hero-image-s3-key");
+  const socialAlternateHeroImageS3Metadata =
+    (alternateSocialMetadata ? alternateSocialMetadata : alternateHomeMetadata) || story["hero-image-metadata"];
 
+  const socialAlternateHeroImageS3Key =
+    (alternateSocialS3Key ? alternateSocialS3Key : alternateHomeS3Key) || story["hero-image-s3-key"];
 
-   const socialAlternateHeroImageS3Metadata = (alternateSocialMetadata ? alternateSocialMetadata : alternateHomeMetadata)  ||  story["hero-image-metadata"];
+  const alt = getAltribution(story);
 
-   const socialAlternateHeroImageS3Key = (alternateSocialS3Key ? alternateSocialS3Key : alternateHomeS3Key) || story["hero-image-s3-key"];
-
-   const alt = story["hero-image-attribution"] || story.summary || get(story, ["alternative", "home", "default", "headline"]) || story.headline;
-
-   return {image: new FocusedImage(socialAlternateHeroImageS3Key, socialAlternateHeroImageS3Metadata || {}), alt};
+  return { image: new FocusedImage(socialAlternateHeroImageS3Key, socialAlternateHeroImageS3Metadata || {}), alt };
 }
 
 function pickImageFromCollection(collection) {
   const coverImage = get(collection, ["metadata", "cover-image"]) || {};
-  if(!coverImage["cover-image-s3-key"])
-    return {};
+  if (!coverImage["cover-image-s3-key"]) return {};
   const alt = collection.summary || collection.name || null;
-  return {image: new FocusedImage(coverImage["cover-image-s3-key"], coverImage["cover-image-metadata"] || {}), alt }
+  return { image: new FocusedImage(coverImage["cover-image-s3-key"], coverImage["cover-image-metadata"] || {}), alt };
 }
 
 // The image is grabbed from the story, else from from the collection
 function pickImage(pageType, data, url) {
-  if(pageType === 'story-page' && url.query && url.query.cardId) {
-    const story = get(data, ['data', 'story']) || {};
+  if (pageType === "story-page" && url.query && url.query.cardId) {
+    const story = get(data, ["data", "story"]) || {};
     return pickImageFromCard(story, url.query.cardId) || pickImageFromStory(story);
-  }else if(pageType === 'visual-story' && url.query && url.query.cardId) {
-    const story = get(data, ['story']) || {};
+  } else if (pageType === "visual-story" && url.query && url.query.cardId) {
+    const story = get(data, ["story"]) || {};
     return pickImageFromCard(story, url.query.cardId) || pickImageFromStory(story);
-  } else if(pageType === 'story-page' || pageType === 'story-page-amp') {
-    const story = get(data, ['data', 'story']) || {};
+  } else if (pageType === "story-page" || pageType === "story-page-amp") {
+    const story = get(data, ["data", "story"]) || {};
     return pickImageFromStory(story);
-  } else if(pageType === 'visual-story') {
-    const story = get(data, ['story']) || {};
+  } else if (pageType === "visual-story") {
+    const story = get(data, ["story"]) || {};
     return pickImageFromStory(story);
-  } else if(get(data, ['data', 'collection'])) {
-    return pickImageFromCollection(get(data, ['data', 'collection']))
+  } else if (get(data, ["data", "collection"])) {
+    return pickImageFromCollection(get(data, ["data", "collection"]));
   }
 }
 
@@ -70,27 +81,41 @@ function pickImage(pageType, data, url) {
  * @param {boolean} seoConfig.enableTwitterCards Add twitter tags
  * @param {...*} params See {@link Generator} for other Parameters
  */
-export function ImageTags(seoConfig, config, pageType, data, {url = {}}) {
-  const {image, alt} = pickImage(pageType, data, url);
+export function ImageTags(seoConfig, config, pageType, data, { url = {} }) {
+  const { image, alt } = pickImage(pageType, data, url);
 
-  if(!image) {
+  if (!image) {
     return [];
   }
 
   const tags = [];
 
-  if(seoConfig.enableTwitterCards) {
-    tags.push({name: "twitter:image", content: `https://${config['cdn-image']}/${image.path([16, 9], {w: 1200, auto: "format,compress", ogImage: true})}`})
-    tags.push({property: "twitter:image:alt", content: alt})
+  if (seoConfig.enableTwitterCards) {
+    tags.push({
+      name: "twitter:image",
+      content: `https://${config["cdn-image"]}/${image.path([16, 9], {
+        w: 1200,
+        auto: "format,compress",
+        ogImage: true,
+      })}`,
+    });
+    alt && tags.push({ property: "twitter:image:alt", content: alt });
   }
 
-  if(seoConfig.enableOgTags) {
-    tags.push({property: "og:image", content: `https://${config['cdn-image']}/${image.path([40, 21], {w: 1200, auto: "format,compress", ogImage: true})}`});
-    tags.push({property: "og:image:width", content: 1200});
-    if(get(image, ["metadata", "focus-point"])) {
-      tags.push({property: "og:image:height", content: 630})
+  if (seoConfig.enableOgTags) {
+    tags.push({
+      property: "og:image",
+      content: `https://${config["cdn-image"]}/${image.path([40, 21], {
+        w: 1200,
+        auto: "format,compress",
+        ogImage: true,
+      })}`,
+    });
+    tags.push({ property: "og:image:width", content: 1200 });
+    if (get(image, ["metadata", "focus-point"])) {
+      tags.push({ property: "og:image:height", content: 630 });
     }
-    tags.push({property: "og:image:alt", content: alt})
+    alt && tags.push({ property: "og:image:alt", content: alt });
   }
 
   return tags;

--- a/src/image-tags.js
+++ b/src/image-tags.js
@@ -8,7 +8,7 @@ function pickImageFromCard(story, cardId) {
       metadata["social-share"].image.attribution ||
       metadata["social-share"].title ||
       metadata["social-share"].message ||
-      getAltribution(story);
+      getAttribution(story);
     return {
       image: new FocusedImage(metadata["social-share"].image.key, metadata["social-share"].image.metadata || {}),
       alt,
@@ -16,7 +16,7 @@ function pickImageFromCard(story, cardId) {
   }
 }
 
-function getAltribution(story) {
+function getAttribution(story) {
   return (
     story["hero-image-attribution"] ||
     story.summary ||
@@ -41,7 +41,7 @@ function pickImageFromStory(story) {
   const socialAlternateHeroImageS3Key =
     (alternateSocialS3Key ? alternateSocialS3Key : alternateHomeS3Key) || story["hero-image-s3-key"];
 
-  const alt = getAltribution(story);
+  const alt = getAttribution(story);
 
   return { image: new FocusedImage(socialAlternateHeroImageS3Key, socialAlternateHeroImageS3Metadata || {}), alt };
 }

--- a/src/image-tags.js
+++ b/src/image-tags.js
@@ -4,7 +4,11 @@ import { FocusedImage } from "quintype-js";
 function pickImageFromCard(story, cardId) {
   const { metadata = {} } = story.cards.find((card) => card.id === cardId) || {};
   if (metadata && !isEmpty(metadata) && get(metadata, ["social-share", "image", "key"], false)) {
-    const alt = metadata["social-share"].image.attribution || getAltribution(story);
+    const alt =
+      metadata["social-share"].image.attribution ||
+      metadata["social-share"].title ||
+      metadata["social-share"].message ||
+      getAltribution(story);
     return {
       image: new FocusedImage(metadata["social-share"].image.key, metadata["social-share"].image.metadata || {}),
       alt,

--- a/test/image_tags_test.js
+++ b/test/image_tags_test.js
@@ -171,6 +171,197 @@ describe("ImageTags", function() {
     );
   });
 
+  it("gets stroy hero image attribution values instead of card attribution values on story share", function() {
+    const story = {
+      "hero-image-s3-key": "my/image.png",
+      "hero-image-attribution": "attribution test",
+      cards: [
+        {
+          id: "sample-card-id",
+          metadata: {
+            "social-share": {
+              title: "share-card-title",
+              message: "share-card-description",
+              image: {
+                key: "my/card/image.jpg",
+                metadata: {
+                  width: 1300,
+                  height: 1065,
+                  "mime-type": "image/jpeg"
+                }
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    const opts = {
+      url: {
+        query: {
+          cardId: "sample-card-id"
+        }
+      }
+    };
+
+    const string = getSeoMetadata(
+      seoConfig,
+      config,
+      "story-page",
+      { data: { story: story } },
+      opts
+    );
+
+    assertContains('<meta property="twitter:image:alt" content="attribution test"/>', string)
+
+    assertContains('<meta property="og:image:alt" content="attribution test"/>', string)
+
+  });
+
+  it("gets stroy summary as attribution if hero image attribution is not present", function() {
+    const story = {
+      "hero-image-s3-key": "my/image.png",
+      "hero-image-attribution": null,
+      summary: "attribution test",
+      cards: [
+        {
+          id: "sample-card-id",
+          metadata: {
+            "social-share": {
+              title: "share-card-title",
+              message: "share-card-description",
+              image: {
+                key: "my/card/image.jpg",
+                metadata: {
+                  width: 1300,
+                  height: 1065,
+                  "mime-type": "image/jpeg"
+                }
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    const opts = {
+      url: {
+        query: {
+          cardId: "sample-card-id"
+        }
+      }
+    };
+
+    const string = getSeoMetadata(
+      seoConfig,
+      config,
+      "story-page",
+      { data: { story: story } },
+      opts
+    );
+
+    assertContains('<meta property="twitter:image:alt" content="attribution test"/>', string)
+
+    assertContains('<meta property="og:image:alt" content="attribution test"/>', string)
+
+  });
+
+  it("gets stroy headline as attribution if hero image attribution and summary is not present", function() {
+    const story = {
+      "hero-image-s3-key": "my/image.png",
+      "hero-image-attribution": null,
+      summary: null,
+      headline: "attribution test",
+      cards: [
+        {
+          id: "sample-card-id",
+          metadata: {
+            "social-share": {
+              title: "share-card-title",
+              message: "share-card-description",
+              image: {
+                key: "my/card/image.jpg",
+                metadata: {
+                  width: 1300,
+                  height: 1065,
+                  "mime-type": "image/jpeg"
+                }
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    const opts = {
+      url: {
+        query: {
+          cardId: "sample-card-id"
+        }
+      }
+    };
+
+    const string = getSeoMetadata(
+      seoConfig,
+      config,
+      "story-page",
+      { data: { story: story } },
+      opts
+    );
+
+    assertContains('<meta property="twitter:image:alt" content="attribution test"/>', string)
+
+    assertContains('<meta property="og:image:alt" content="attribution test"/>', string)
+
+  });
+
+  it("gets card image attribution values instead of story attribution values on card share", function() {
+    const story = {
+      "hero-image-s3-key": "my/image.png",
+      cards: [
+        {
+          id: "sample-card-id",
+          metadata: {
+            "social-share": {
+              title: "share-card-title",
+              message: "share-card-description",
+              image: {
+                attribution: "attribution test",
+                key: "my/card/image.jpg",
+                metadata: {
+                  width: 1300,
+                  height: 1065,
+                  "mime-type": "image/jpeg"
+                }
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    const opts = {
+      url: {
+        query: {
+          cardId: "sample-card-id"
+        }
+      }
+    };
+
+    const string = getSeoMetadata(
+      seoConfig,
+      config,
+      "story-page",
+      { data: { story: story } },
+      opts
+    );
+
+    assertContains('<meta property="twitter:image:alt" content="attribution test"/>', string)
+
+    assertContains('<meta property="og:image:alt" content="attribution test"/>', string)
+
+  });
+
   it("gets story data as fallback if the card metadata is falsy", function() {
     const story = {
       "hero-image-s3-key": "my/image.png",

--- a/test/image_tags_test.js
+++ b/test/image_tags_test.js
@@ -171,7 +171,7 @@ describe("ImageTags", function() {
     );
   });
 
-  it("gets stroy hero image attribution values instead of card attribution values on story share", function() {
+  it("gets story hero image attribution values instead of card attribution values on story share", function() {
     const story = {
       "hero-image-s3-key": "my/image.png",
       "hero-image-attribution": "attribution test",
@@ -184,6 +184,7 @@ describe("ImageTags", function() {
               message: "share-card-description",
               image: {
                 key: "my/card/image.jpg",
+                attribution: null,
                 metadata: {
                   width: 1300,
                   height: 1065,
@@ -218,7 +219,7 @@ describe("ImageTags", function() {
 
   });
 
-  it("gets stroy summary as attribution if hero image attribution is not present", function() {
+  it("gets story summary as attribution if hero image attribution is not present", function() {
     const story = {
       "hero-image-s3-key": "my/image.png",
       "hero-image-attribution": null,
@@ -266,7 +267,7 @@ describe("ImageTags", function() {
 
   });
 
-  it("gets stroy headline as attribution if hero image attribution and summary is not present", function() {
+  it("gets story headline as attribution if hero image attribution and summary is not present", function() {
     const story = {
       "hero-image-s3-key": "my/image.png",
       "hero-image-attribution": null,
@@ -318,6 +319,7 @@ describe("ImageTags", function() {
   it("gets card image attribution values instead of story attribution values on card share", function() {
     const story = {
       "hero-image-s3-key": "my/image.png",
+      headline: "story headline",
       cards: [
         {
           id: "sample-card-id",

--- a/test/image_tags_test.js
+++ b/test/image_tags_test.js
@@ -197,13 +197,7 @@ describe("ImageTags", function() {
       ]
     };
 
-    const opts = {
-      url: {
-        query: {
-          cardId: "sample-card-id"
-        }
-      }
-    };
+    const opts = {};
 
     const string = getSeoMetadata(
       seoConfig,
@@ -245,13 +239,7 @@ describe("ImageTags", function() {
       ]
     };
 
-    const opts = {
-      url: {
-        query: {
-          cardId: "sample-card-id"
-        }
-      }
-    };
+    const opts = {};
 
     const string = getSeoMetadata(
       seoConfig,
@@ -294,13 +282,7 @@ describe("ImageTags", function() {
       ]
     };
 
-    const opts = {
-      url: {
-        query: {
-          cardId: "sample-card-id"
-        }
-      }
-    };
+    const opts = {};
 
     const string = getSeoMetadata(
       seoConfig,
@@ -444,6 +426,38 @@ describe("ImageTags", function() {
       );
       assertContains(
         '<meta property="og:image:height" content="630"/>',
+        string
+      );
+    });
+
+    it("pulls images with alt from the collection if present", function() {
+      const collection = {
+        name: "collection name",
+        summary: "collection summary",
+        metadata: {
+          "cover-image": {
+            "cover-image-s3-key": "my/image.png",
+            "cover-image-metadata": {
+              width: 2400,
+              height: 1260,
+              "focus-point": [0, 0]
+            }
+          }
+        }
+      };
+      const string = getSeoMetadata(
+        seoConfig,
+        config,
+        "home-page",
+        { data: { collection: collection } },
+        {}
+      );
+      assertContains(
+        '<meta property="og:image:alt" content="collection summary"/>',
+        string
+      );
+      assertContains(
+        '<meta property="twitter:image:alt" content="collection summary"/>',
         string
       );
     });


### PR DESCRIPTION
There is no error while checking the story online on the Facebook debugger tool [here](https://developers.facebook.com/tools/debug/). but when I run [Structured Data Testing Tool](https://www.npmjs.com/package/structured-data-testing-tool) through the command line
ex:
```
sdtt --url https://www.prothomalo.com/bangladesh/%E0%A6%B8%E0%A6%AC%E0%A6%9A%E0%A7%87%E0%A7%9F%E0%A7%87-%E0%A6%95%E0%A6%A0%E0%A7%8B%E0%A6%B0%E0%A6%A4%E0%A6%AE-%E0%A6%AC%E0%A6%BF%E0%A6%A7%E0%A6%BF%E0%A6%A8%E0%A6%BF%E0%A6%B7%E0%A7%87%E0%A6%A7-%E0%A6%B6%E0%A7%81%E0%A6%B0%E0%A7%81-%E0%A6%95%E0%A6%BE%E0%A6%B2-%E0%A6%A5%E0%A7%87%E0%A6%95%E0%A7%87%E0%A6%87 --presets Google, SocialMedia  Tests -i`

```
it's throwing error, saying that **og:image:alt** and **twitter:image:alt** not found.


some docs

 https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/abouts-cards,
 https://ogp.me/, 
https://swimburger.net/blog/web/dont-forget-to-provide-image-alt-meta-data-for-open-graph-and-twitter-cards-social-sharing

Ticket - https://github.com/quintype/ace-planning/issues/486