### PR TITLE
remove is-amp-supported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.3",
+  "version": "1.40.4-amptag.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.3",
+  "version": "1.40.4-amptag.0",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/src/amp-tags.js
+++ b/src/amp-tags.js
@@ -6,10 +6,6 @@ function showAmpTag({ ampStoryPages = true }, pageType, story) {
     return false;
   }
 
-  if (!get(story, ["is-amp-supported"])) {
-    return false;
-  }
-
   if (ampStoryPages === 'public' && !isStoryPublic(story)) {
     return false;
   }

--- a/test/amp_tags_test.js
+++ b/test/amp_tags_test.js
@@ -6,60 +6,84 @@ const assert = require('assert');
 describe('AmpTags', function () {
   const seoConfig = {
     generators: [StoryAmpTags],
-    ampStoryPages: true
-  }
+    ampStoryPages: true,
+  };
 
   const config = {
-    'sketches-host': 'https://madrid.quintype.io'
-  }
+    "sketches-host": "https://madrid.quintype.io",
+  };
 
-  it("gets amp tags for supported stories", function() {
-    const story = {"slug": "section/slug", "is-amp-supported": true}
-    const string = getSeoMetadata(seoConfig, config, 'story-page', {data: {story: story}}, {})
+  it("gets amp tags for supported stories", function () {
+    const story = { slug: "section/slug", "is-amp-supported": true };
+    const string = getSeoMetadata(seoConfig, config, "story-page", { data: { story: story } }, {});
     assertContains('<link rel="amphtml" href="/amp/story/section%2Fslug"/>', string);
   });
 
-  it("does not ampify any non supported stories", function () {
-    const story = { "slug": "section/slug", "is-amp-supported": false }
-    const string = getSeoMetadata(seoConfig, config, 'story-page', { data: { story: story } }, {})
-    assert.equal('', string);
-  });
+  // FIX THIS LATER -- AMOGH
+  // it("does not ampify any non supported stories", function () {
+  //   const story = { "slug": "section/slug", "is-amp-supported": false }
+  //   const string = getSeoMetadata(seoConfig, config, 'story-page', { data: { story: story } }, {})
+  //   assert.equal('', string);
+  // });
 
   it("does not add amphtml link tag to amp story pages", function () {
-    const story = { "slug": "section/slug", "is-amp-supported": true }
-    const string = getSeoMetadata(seoConfig, config, 'story-page-amp', { data: { story: story } }, {})
-    assert.equal('', string);
+    const story = { slug: "section/slug", "is-amp-supported": true };
+    const string = getSeoMetadata(seoConfig, config, "story-page-amp", { data: { story: story } }, {});
+    assert.equal("", string);
   });
 
   it("does not ampify other pages", function () {
-    const string = getSeoMetadata(seoConfig, config, 'home-page', { data: {} }, {})
-    assert.equal('', string);
+    const string = getSeoMetadata(seoConfig, config, "home-page", { data: {} }, {});
+    assert.equal("", string);
   });
 
   it("does allows you to only ampify free story pages", function () {
-    const story = { "slug": "section/slug", "is-amp-supported": true }
-    const publicStoryResults = getSeoMetadata({...seoConfig, ampStoryPages: "public"}, config, 'story-page', { data: { story: story } }, {})
+    const story = { slug: "section/slug", "is-amp-supported": true };
+    const publicStoryResults = getSeoMetadata(
+      { ...seoConfig, ampStoryPages: "public" },
+      config,
+      "story-page",
+      { data: { story: story } },
+      {}
+    );
     assert.equal('<link rel="amphtml" href="/amp/story/section%2Fslug"/>', publicStoryResults);
-    const privateStoryResults = getSeoMetadata({ ...seoConfig, ampStoryPages: "public" }, config, 'story-page', { data: { story: {...story, access: "subscription"} } }, {})
-    assert.equal('', privateStoryResults);
-  })
+    const privateStoryResults = getSeoMetadata(
+      { ...seoConfig, ampStoryPages: "public" },
+      config,
+      "story-page",
+      { data: { story: { ...story, access: "subscription" } } },
+      {}
+    );
+    assert.equal("", privateStoryResults);
+  });
 
   it("does not append domain to amp stories if appendHostToAmpUrl not present", function () {
-    const story = {"slug": "section/slug", "is-amp-supported": true}
-    const string = getSeoMetadata(seoConfig, config, 'story-page', {data: {story: story}}, {})
+    const story = { slug: "section/slug", "is-amp-supported": true };
+    const string = getSeoMetadata(seoConfig, config, "story-page", { data: { story: story } }, {});
     assertContains('<link rel="amphtml" href="/amp/story/section%2Fslug"/>', string);
-  })
+  });
 
   it("does append domain to amp stories if appendHostToAmpUrl present", function () {
-    const story = {"slug": "section/slug", "is-amp-supported": true}
-    const string = getSeoMetadata({...seoConfig, appendHostToAmpUrl: true}, config, 'story-page', {currentHostUrl: "https://madrid.quintype.io/section/slug", data: {story}}, {})
+    const story = { slug: "section/slug", "is-amp-supported": true };
+    const string = getSeoMetadata(
+      { ...seoConfig, appendHostToAmpUrl: true },
+      config,
+      "story-page",
+      { currentHostUrl: "https://madrid.quintype.io/section/slug", data: { story } },
+      {}
+    );
     assertContains('<link rel="amphtml" href="https://madrid.quintype.io/amp/story/section%2Fslug"/>', string);
-  })
+  });
 
   it("does encode the url if encodeAmpUrl is set to false in seoConfig", function () {
-    const story = {"slug": "section%2Fslug", "is-amp-supported": true}
-    const string = getSeoMetadata({...seoConfig, appendHostToAmpUrl: true, decodeAmpUrl: true}, config, 'story-page', {currentHostUrl: "https://madrid.quintype.io/section%2Fslug", data: {story}}, {})
+    const story = { slug: "section%2Fslug", "is-amp-supported": true };
+    const string = getSeoMetadata(
+      { ...seoConfig, appendHostToAmpUrl: true, decodeAmpUrl: true },
+      config,
+      "story-page",
+      { currentHostUrl: "https://madrid.quintype.io/section%2Fslug", data: { story } },
+      {}
+    );
     assertContains('<link rel="amphtml" href="https://madrid.quintype.io/amp/story/section/slug"/>', string);
-  })
-
+  });
 });


### PR DESCRIPTION
remove logic that prevents generating `amphtml` meta tag on story page if story API `is-amp-supported` is false. We aren't relying on `is-amp-supported` anymore