### PR TITLE
fix(video-structured-data): use correct embed url

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,6 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "editor.tabSize": 2,
-  "editor.formatOnSave": false,
   "editor.detectIndentation": false,
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
   },
   "editor.tabSize": 2,
   "editor.detectIndentation": false,
+  "editor.formatOnSave": true,
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
   "editor.codeActionsOnSave": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "editor.tabSize": 2,
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "editor.detectIndentation": false,
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.6-embed-url.0",
+  "version": "1.40.6-embed-url.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.5",
+  "version": "1.40.6-embed-url.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.6-embed-url.2",
+  "version": "1.40.6-embed-url.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.6-embed-url.3",
+  "version": "1.40.6-embed-url.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.6-embed-url.1",
+  "version": "1.40.6-embed-url.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.7",
+  "version": "1.40.8-embed-url.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/seo",
-      "version": "1.40.7",
+      "version": "1.40.8-embed-url.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^2.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.6-embed-url.1",
+  "version": "1.40.6-embed-url.2",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.6-embed-url.0",
+  "version": "1.40.6-embed-url.1",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.6-embed-url.3",
+  "version": "1.40.6-embed-url.4",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.6-embed-url.2",
+  "version": "1.40.6-embed-url.3",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.7",
+  "version": "1.40.8-embed-url.0",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.40.5",
+  "version": "1.40.6-embed-url.0",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/src/structured-data/structured-data-tags.js
+++ b/src/structured-data/structured-data-tags.js
@@ -11,7 +11,7 @@ import {
   getSchemaPerson,
   getSchemaPublisher,
   getSchemaType,
-  getSchemaWebsite
+  getSchemaWebsite,
 } from "./schema";
 
 function getLdJsonFields(type, fields) {
@@ -262,6 +262,7 @@ function getEmbedUrl(cards) {
   // find is used for early exit
   cards.find((card) => {
     const storyElements = card["story-elements"];
+
     return storyElements.find((elem, index) => {
       if (elem["embed-url"]) {
         embedUrl = elem["embed-url"];
@@ -273,7 +274,6 @@ function getEmbedUrl(cards) {
 
   return embedUrl;
 }
-
 
 function generateVideoArticleData(structuredData = {}, story = {}, publisherConfig = {}, timezone) {
   const metaKeywords = (story.seo && story.seo["meta-keywords"]) || [];

--- a/src/structured-data/structured-data-tags.js
+++ b/src/structured-data/structured-data-tags.js
@@ -254,9 +254,7 @@ function generateLiveBlogPostingData(structuredData = {}, story = {}, publisherC
   };
 }
 
-function getEmbedUrl(story) {
-  const { cards } = story;
-
+function getEmbedUrl({cards}) {
   for (let i = 0; i < cards.length; i++) {
     const storyElements = cards[i]["story-elements"];
     for (let j = 0; j < storyElements.length; j++) {

--- a/src/structured-data/structured-data-tags.js
+++ b/src/structured-data/structured-data-tags.js
@@ -11,7 +11,7 @@ import {
   getSchemaPerson,
   getSchemaPublisher,
   getSchemaType,
-  getSchemaWebsite
+  getSchemaWebsite,
 } from "./schema";
 
 function getLdJsonFields(type, fields) {
@@ -254,24 +254,24 @@ function generateLiveBlogPostingData(structuredData = {}, story = {}, publisherC
   };
 }
 
-function getEmbedUrl({cards}) {
+function getEmbedUrl(cards) {
   for (let i = 0; i < cards.length; i++) {
     const storyElements = cards[i]["story-elements"];
     for (let j = 0; j < storyElements.length; j++) {
       const storyElement = storyElements[j];
       if (storyElement["embed-url"]) {
-        return storyElement["embed-url"]
+        return storyElement["embed-url"];
       }
     }
-
   }
 
-  return ''
+  return "";
 }
 
 function generateVideoArticleData(structuredData = {}, story = {}, publisherConfig = {}, timezone) {
   const metaKeywords = (story.seo && story.seo["meta-keywords"]) || [];
-  const embedUrl = getEmbedUrl(story)
+  const storyCards = get(story, ["cards"], []);
+  const embedUrl = getEmbedUrl(storyCards);
   const socialShareMsg = get(story, ["summary"], "");
   const metaDescription = get(story, ["seo", "meta-description"], "");
   const subHeadline = get(story, ["subheadline"], "");
@@ -491,10 +491,7 @@ export function StructuredDataTags({ structuredData = {} }, config, pageType, re
     }
 
     if (structuredData.enableVideo && story["story-template"] === "video") {
-      return ldJson(
-        "VideoObject",
-        generateVideoArticleData(structuredData, story, publisherConfig, timezone)
-      );
+      return ldJson("VideoObject", generateVideoArticleData(structuredData, story, publisherConfig, timezone));
     }
 
     if (structuredData.enableNewsArticle !== "withoutArticleSchema") {

--- a/src/structured-data/structured-data-tags.js
+++ b/src/structured-data/structured-data-tags.js
@@ -256,6 +256,7 @@ function generateLiveBlogPostingData(structuredData = {}, story = {}, publisherC
 
 function getEmbedUrl(cards) {
   // get the first story element which has the embed url
+  // one more comment
   const storyElement = cards
     .flatMap((card) => card["story-elements"])
     .find((elem) => elem["embed-url"]);

--- a/src/structured-data/structured-data-tags.js
+++ b/src/structured-data/structured-data-tags.js
@@ -255,25 +255,23 @@ function generateLiveBlogPostingData(structuredData = {}, story = {}, publisherC
 }
 
 function getEmbedUrl(cards) {
-  // get the first story element which has the embed url
+  let embedUrl = "";
 
-  let storyElemIndex;
-
-  const card = cards.find((card) => {
+  // not using the return value of top level find
+  // coz we only need the embed url
+  // find is used for early exit
+  cards.find((card) => {
     const storyElements = card["story-elements"];
     return storyElements.find((elem, index) => {
       if (elem["embed-url"]) {
-        storyElemIndex = index;
-        return elem["embed-url"];
+        embedUrl = elem["embed-url"];
+        return true;
       }
       return false;
     });
   });
-  if (card) {
-    const storyElement = card['story-elements'][storyElemIndex]
-    return storyElement["embed-url"];
-  }
-  return "";
+
+  return embedUrl;
 }
 
 

--- a/src/structured-data/structured-data-tags.js
+++ b/src/structured-data/structured-data-tags.js
@@ -256,11 +256,22 @@ function generateLiveBlogPostingData(structuredData = {}, story = {}, publisherC
 
 function getEmbedUrl(cards) {
   // get the first story element which has the embed url
-  const storyElement = cards
-    .flatMap((card) => card["story-elements"])
-    .find((elem) => elem["embed-url"]);
-  if (storyElement) {
-    return  storyElement["embed-url"];
+
+  let storyElemIndex;
+
+  const card = cards.find((card) => {
+    const storyElements = card["story-elements"];
+    return storyElements.find((elem, index) => {
+      if (elem["embed-url"]) {
+        storyElemIndex = index;
+        return elem["embed-url"];
+      }
+      return false;
+    });
+  });
+  if (card) {
+    const storyElement = card['story-elements'][storyElemIndex]
+    return storyElement["embed-url"];
   }
   return "";
 }

--- a/src/structured-data/structured-data-tags.js
+++ b/src/structured-data/structured-data-tags.js
@@ -254,9 +254,26 @@ function generateLiveBlogPostingData(structuredData = {}, story = {}, publisherC
   };
 }
 
+function getEmbedUrl(story) {
+  const { cards } = story;
+
+  for (let i = 0; i < cards.length; i++) {
+    const storyElements = cards[i]["story-elements"];
+    for (let j = 0; j < storyElements.length; j++) {
+      const storyElement = storyElements[j];
+      if (storyElement["embed-url"]) {
+        return storyElement["embed-url"]
+      }
+    }
+
+  }
+
+  return ''
+}
+
 function generateVideoArticleData(structuredData = {}, story = {}, publisherConfig = {}, timezone) {
   const metaKeywords = (story.seo && story.seo["meta-keywords"]) || [];
-  const embedUrl = get(story, ["cards", "0", "story-elements", "0", "embed-url"], "");
+  const embedUrl = getEmbedUrl(story)
   const socialShareMsg = get(story, ["summary"], "");
   const metaDescription = get(story, ["seo", "meta-description"], "");
   const subHeadline = get(story, ["subheadline"], "");

--- a/src/structured-data/structured-data-tags.js
+++ b/src/structured-data/structured-data-tags.js
@@ -11,7 +11,7 @@ import {
   getSchemaPerson,
   getSchemaPublisher,
   getSchemaType,
-  getSchemaWebsite,
+  getSchemaWebsite
 } from "./schema";
 
 function getLdJsonFields(type, fields) {
@@ -255,18 +255,16 @@ function generateLiveBlogPostingData(structuredData = {}, story = {}, publisherC
 }
 
 function getEmbedUrl(cards) {
-  for (let i = 0; i < cards.length; i++) {
-    const storyElements = cards[i]["story-elements"];
-    for (let j = 0; j < storyElements.length; j++) {
-      const storyElement = storyElements[j];
-      if (storyElement["embed-url"]) {
-        return storyElement["embed-url"];
-      }
-    }
+  // get the first story element which has the embed url
+  const storyElement = cards
+    .flatMap((card) => card["story-elements"])
+    .find((elem) => elem["embed-url"]);
+  if (storyElement) {
+    return  storyElement["embed-url"];
   }
-
   return "";
 }
+
 
 function generateVideoArticleData(structuredData = {}, story = {}, publisherConfig = {}, timezone) {
   const metaKeywords = (story.seo && story.seo["meta-keywords"]) || [];

--- a/src/structured-data/structured-data-tags.js
+++ b/src/structured-data/structured-data-tags.js
@@ -262,7 +262,6 @@ function getEmbedUrl(cards) {
   // find is used for early exit
   cards.find((card) => {
     const storyElements = card["story-elements"];
-
     return storyElements.find((elem, index) => {
       if (elem["embed-url"]) {
         embedUrl = elem["embed-url"];

--- a/src/structured-data/structured-data-tags.js
+++ b/src/structured-data/structured-data-tags.js
@@ -256,7 +256,6 @@ function generateLiveBlogPostingData(structuredData = {}, story = {}, publisherC
 
 function getEmbedUrl(cards) {
   // get the first story element which has the embed url
-  // one more comment
   const storyElement = cards
     .flatMap((card) => card["story-elements"])
     .find((elem) => elem["embed-url"]);


### PR DESCRIPTION
# Description
fixes https://github.com/quintype/page-builder/issues/1919.

Earlier, the embed URL was only picked from the first card. This fix will ensure the embed URL is picked from the first video regardless of which card the video is in. The video can be in the 2nd card and that embed URL will be picked.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test Case A
- [ ] Test Case B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
