### PR TITLE
feat(amp): disable amp for a particular story 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/seo",
-  "version": "1.43.0-disable-amp-story.0",
+  "version": "1.43.0-disable-amp-story.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/seo",
-      "version": "1.43.0-disable-amp-story.0",
+      "version": "1.43.0-disable-amp-story.1",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^2.17.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/seo",
-  "version": "1.42.2",
+  "version": "1.43.0-disable-amp-story.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/seo",
-      "version": "1.42.2",
+      "version": "1.43.0-disable-amp-story.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^2.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.42.2",
+  "version": "1.43.0-disable-amp-story.0",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.43.0-disable-amp-story.0",
+  "version": "1.43.0-disable-amp-story.1",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/src/amp-tags.js
+++ b/src/amp-tags.js
@@ -6,7 +6,7 @@ function showAmpTag({ ampStoryPages = true }, pageType, story) {
     return false;
   }
 
-  const isAmpDisabled = get(story, ["metadata", "story-attributes", "disableamp", "0"], "false");
+  const isAmpDisabled = get(story, ["metadata", "story-attributes", "disable-amp-for-single-story", "0"], "false");
 
   if (isAmpDisabled === "true") {
     return false;

--- a/src/amp-tags.js
+++ b/src/amp-tags.js
@@ -6,6 +6,12 @@ function showAmpTag({ ampStoryPages = true }, pageType, story) {
     return false;
   }
 
+  const isAmpDisabled = get(story, ["metadata", "story-attributes", "disableamp", "0"], "false");
+
+  if (isAmpDisabled === "true") {
+    return false;
+  }
+
   if (ampStoryPages === "public" && !isStoryPublic(story)) {
     return false;
   }

--- a/src/amp-tags.js
+++ b/src/amp-tags.js
@@ -31,6 +31,9 @@ const getDomain = (url, domainSlug) => {
 /**
  * StoryAmpTags adds the amphref to stories which support amp.
  *
+ * To disable adding amphref for a specific story, you need to create a story attribute in bold with the slug {disable-amp-for-single-story} and values {true} and {false}. Set its value to "true" in the story which you want to disable amp. Please make sure to name the attributes and values in the exact same way as mentioned
+ * attribute slug: "disable-amp-for-single-story" values: "true" , "false"
+ *
  * @extends Generator
  * @param {*} seoConfig
  * @param {(boolean|"public")} seoConfig.ampStoryPages Should amp story pages be shown for all stories (true), not shown (false), or only be shown for public stories ("public"). Default: true

--- a/test/amp_tags_test.js
+++ b/test/amp_tags_test.js
@@ -29,17 +29,17 @@ describe("AmpTags", function () {
     const story = {
       slug: "section/slug",
       "is-amp-supported": true,
-      metadata: { "story-attributes": { disableamp: ["true"] } },
+      metadata: { "story-attributes": { "disable-amp-for-single-story": ["true"] } },
     };
     const string = getSeoMetadata(seoConfig, config, "story-page", { data: { story: story } }, {});
     assert.equal("", string);
   });
 
-  it("does not add amphtml link tag to story pages which has disableamp attribute set to true", function () {
+  it("does not add amphtml link tag to story pages which has disableamp attribute set to false", function () {
     const story = {
       slug: "section/slug",
       "is-amp-supported": true,
-      metadata: { "story-attributes": { disableamp: ["false"] } },
+      metadata: { "story-attributes": { "disable-amp-for-single-story": ["false"] } },
     };
     const string = getSeoMetadata(seoConfig, config, "story-page", { data: { story: story } }, {});
     assert.equal('<link rel="amphtml" href="/amp/story/section%2Fslug"/>', string);

--- a/test/amp_tags_test.js
+++ b/test/amp_tags_test.js
@@ -25,6 +25,26 @@ describe("AmpTags", function () {
     assertContains('<link rel="amphtml" href="/amp/story/section%2Fslug"/>', string);
   });
 
+  it("does not add amphtml link tag to story pages which has disableamp attribute set to true", function () {
+    const story = {
+      slug: "section/slug",
+      "is-amp-supported": true,
+      metadata: { "story-attributes": { disableamp: ["true"] } },
+    };
+    const string = getSeoMetadata(seoConfig, config, "story-page", { data: { story: story } }, {});
+    assert.equal("", string);
+  });
+
+  it("does not add amphtml link tag to story pages which has disableamp attribute set to true", function () {
+    const story = {
+      slug: "section/slug",
+      "is-amp-supported": true,
+      metadata: { "story-attributes": { disableamp: ["false"] } },
+    };
+    const string = getSeoMetadata(seoConfig, config, "story-page", { data: { story: story } }, {});
+    assert.equal('<link rel="amphtml" href="/amp/story/section%2Fslug"/>', string);
+  });
+
   it("does not add amphtml link tag to amp story pages", function () {
     const story = { slug: "section/slug", "is-amp-supported": true };
     const string = getSeoMetadata(seoConfig, config, "story-page-amp", { data: { story: story } }, {});


### PR DESCRIPTION
Reference: https://github.com/quintype/ace-planning/issues/988

Client has to create a story attribute with the slug "disable-amp-for-single-story" and set its value to true to enable this feature. When that attribute is set to true we redirect back to the non-amp page without creating an amp version for that story.

This pr adds the support to skip creating StoryAmpTags for the story when there is "disable-amp-for-single-story"  attribute set to true