### PR TITLE
feat(Default Collection): Avail Canonical Url field for Default Collections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12134,8 +12134,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "add-stream": {
       "version": "1.0.0",
@@ -13440,8 +13439,7 @@
     "date-fns-tz": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.7.tgz",
-      "integrity": "sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==",
-      "requires": {}
+      "integrity": "sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g=="
     },
     "dateformat": {
       "version": "3.0.3",
@@ -13934,15 +13932,13 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-config-standard": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
       "integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -14077,8 +14073,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
       "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-react": {
       "version": "7.31.11",
@@ -14129,8 +14124,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
       "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -15881,8 +15875,7 @@
       "version": "8.6.5",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
       "integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "marked": {
       "version": "4.2.3",
@@ -17177,8 +17170,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/react-frame-component/-/react-frame-component-5.2.3.tgz",
       "integrity": "sha512-r+h0o3r/uqOLNT724z4CRVkxQouKJvoi3OPfjqWACD30Y87rtEmeJrNZf1WYPGknn1Y8200HAjx7hY/dPUGgmA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-is": {
       "version": "16.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintype/seo",
-  "version": "1.44.1",
+  "version": "1.44.2-seo-coll-canonical.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintype/seo",
-      "version": "1.44.1",
+      "version": "1.44.2-seo-coll-canonical.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^2.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/seo",
-  "version": "1.44.1",
+  "version": "1.44.2-seo-coll-canonical.0",
   "description": "SEO Modules for Quintype",
   "main": "dist/index.cjs.js",
   "repository": "https://github.com/quintype/quintype-node-seo",

--- a/src/text-tags.js
+++ b/src/text-tags.js
@@ -179,13 +179,14 @@ function getSeoData(config, pageType, data, url = {}, seoConfig = {}) {
     const { sections = [] } = config;
     const section = sections.find((section) => ownerType == "section" && section.id === ownerId) || {};
     const customSeo = get(data, ["data", "customSeo"], {});
+    const sectionCollMetadata = get(data, ["data", "collection", "metadata"], {});
     if (seoMetadata.data || section.id || !isEmpty(customSeo)) {
       const result = Object.assign(
         {},
         {
           "page-title": customSeo["page-title"] || section.name,
           title: customSeo.title || section.name,
-          canonicalUrl: customSeo["canonicalUrl"] || section["section-url"] || undefined,
+          canonicalUrl: customSeo["canonicalUrl"] || sectionCollMetadata["canonical-url"] || section["section-url"] || undefined,
         },
         seoMetadata.data
       );
@@ -260,7 +261,7 @@ function getSeoData(config, pageType, data, url = {}, seoConfig = {}) {
 
 function getSeoDataFromCollection(config, data) {
   if (get(data, ["data", "collection", "name"])) {
-    let { name, summary } = get(data, ["data", "collection"]);
+    let { name, summary, metadata } = get(data, ["data", "collection"]);
     const customSeo = get(data, ["data", "customSeo"], {});
 
     if (!summary) {
@@ -271,13 +272,14 @@ function getSeoDataFromCollection(config, data) {
     const ogTitle = customSeo.ogTitle || title;
     const description = customSeo.description || summary;
     const ogDescription = customSeo.ogDescription || summary;
+    const collCanonicalUrl = metadata["canonical-url"] || SKIP_CANONICAL;
     return {
       "page-title": pageTitle,
       title,
       ogTitle,
       description,
       ogDescription,
-      canonicalUrl: SKIP_CANONICAL,
+      canonicalUrl: collCanonicalUrl,
     };
   }
 }

--- a/test/text_tags_test.js
+++ b/test/text_tags_test.js
@@ -201,13 +201,30 @@ describe('TextTags', function () {
           "sections": [],
           "seo-metadata": []
         };
-        const collection = { name: "Collection Title", summary: "Collection Description" };
+        const collection = { name: "Collection Title", summary: "Collection Description", metadata: {} };
         const string = getSeoMetadata(seoConfig, config, 'section-page', { data: { collection } }, { url: url.parse("/") });
         assertContains('<title>Collection Title</title>', string);
         assertContains('<meta name="description" content="Collection Description"/>', string);
         assertContains('<meta name="title" content="Collection Title"/>', string);
         assertDoesNotContains('canonical', string);
         assertDoesNotContains('og:url', string);
+      });
+
+      it("fallback to collection canonical url if someone passes a section-page with no customSeo metadata", function () {
+        const seoConfig = {
+          generators: [TextTags],
+        };
+        const config = {
+          'sketches-host': "http://foo.com",
+          "sections": [],
+          "seo-metadata": []
+        };
+        const collection = { name: "Collection Title", summary: "Collection Description", metadata: { "canonical-url": "http://bar123.com" } };
+        const string = getSeoMetadata(seoConfig, config, 'section-page', { data: { collection } }, { url: url.parse("/") });
+        assertContains('<title>Collection Title</title>', string);
+        assertContains('<meta name="description" content="Collection Description"/>', string);
+        assertContains('<meta name="title" content="Collection Title"/>', string);
+        assertContains('<link rel="canonical" href="http://bar123.com"/>', string);
       });
 
       it("picks up the home page description if the collection is missing the description", function () {
@@ -219,7 +236,7 @@ describe('TextTags', function () {
           "sections": [],
           "seo-metadata": [{ "owner-type": 'home', "owner-id": null, data: { 'description': 'Home Description' } }]
         };
-        const collection = { name: "Collection Title" };
+        const collection = { name: "Collection Title", metadata: {} };
         const string = getSeoMetadata(seoConfig, config, 'section-page', { data: { collection } }, { url: url.parse("/") });
         assertContains('<title>Collection Title</title>', string);
         assertContains('<meta name="description" content="Home Description"/>', string);
@@ -235,7 +252,7 @@ describe('TextTags', function () {
           "sections": [],
           "seo-metadata": []
         };
-        const collection = { name: "Collection Title" };
+        const collection = { name: "Collection Title", metadata: {} };
         const string = getSeoMetadata(seoConfig, config, 'section-page', { data: { collection } }, { url: url.parse("/") });
         assertContains('<title>Collection Title</title>', string);
         assertDoesNotContains('description', string);
@@ -830,7 +847,7 @@ describe('TextTags', function () {
         "sections": [],
         "seo-metadata": []
       };
-      const collection = { name: "Collection Title", summary: "Collection Description" };
+      const collection = { name: "Collection Title", summary: "Collection Description", metadata: {} };
       const string = getSeoMetadata(seoConfig, config, 'collection-page', { data: { collection } }, { url: url.parse("/") });
       assertContains('<title>Collection Title</title>', string);
       assertContains('<meta name="description" content="Collection Description"/>', string);
@@ -838,6 +855,7 @@ describe('TextTags', function () {
       assertDoesNotContains('canonical', string);
       assertDoesNotContains('og:url', string);
     });
+
     it("Gets home data as fallback if the collection data is falsy", function () {
       const seoConfig = {
         generators: [TextTags],


### PR DESCRIPTION
# Description

Vikatan Needs to capture canonical for Default Collection too. 

Fixes # (issue-reference)
https://github.com/quintype/ace-planning/issues/1025


## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)




# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

